### PR TITLE
feat(RELEASE-1486): add_samples_to_the_tenant_catalog

### DIFF
--- a/pipelines/notify-slack-on-failure/README.md
+++ b/pipelines/notify-slack-on-failure/README.md
@@ -1,0 +1,13 @@
+# notify-slack-on-failure pipeline
+
+Sends an error message to Slack using postMessage API if managed pipelines fail.
+
+## Parameters
+
+| Name                                | Description                                                                                                                | Optional   | Default value                                             |
+|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------|------------|-----------------------------------------------------------|
+| secretName                          | Name of secret which contains authentication token for app                                                                 | No         | -                                                         |
+| secretKeyName                       | Name of key within secret which contains webhook URL                                                                       | No         | -                                                         |
+| release                             | Namespaced name of release - should be in format "namespace/name"                                                          | No         | -                                                         |
+| taskGitUrl                          | The url to the git repo where the community-catalog tasks to be used are stored                                            | Yes        | https://github.com/konflux-ci/community-catalog.git       |
+| taskGitRevision                     | The revision in the taskGitUrl repo to be used                                                                             | No         | -                                                         |

--- a/pipelines/notify-slack-on-failure/notify-slack-on-failure.yaml
+++ b/pipelines/notify-slack-on-failure/notify-slack-on-failure.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: notify-slack-on-failure
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: Sends an error message to Slack using postMessage API if managed pipelines fail
+  params:
+    - name: secretName
+      type: string
+      description: Name of secret which contains authentication token for app
+    - name: secretKeyName
+      type: string
+      description: Name of key within secret which contains webhook URL
+    - name: release
+      type: string
+      description: Namespaced name of release - should be in format "namespace/name"
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the community-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/community-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  tasks:
+    - name: notify-slack-on-failure
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/notify-slack-on-failure/notify-slack-on-failure.yaml
+      params:
+        - name: secretName
+          value: $(params.secretName)
+        - name: secretKeyName
+          value: $(params.secretKeyName)
+        - name: release
+          value: $(params.release)

--- a/tasks/notify-slack-on-failure/README.md
+++ b/tasks/notify-slack-on-failure/README.md
@@ -1,0 +1,11 @@
+# notify-slack-on-failure
+
+Tekton task that sends an error message to Slack using postMessage API if managed pipelines fail.
+
+## Parameters
+
+| Name                                | Description                                                                                                                | Optional   | Default value                                             |
+|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------|------------|-----------------------------------------------------------|
+| secretName                          | Name of secret which contains authentication token for app                                                                 | No         | -                                                         |
+| secretKeyName                       | Name of key within secret which contains webhook URL                                                                       | No         | -                                                         |
+| release                             | Namespaced name of release - should be in format "namespace/name"                                                          | No         | -                                                         |

--- a/tasks/notify-slack-on-failure/notify-slack-on-failure.yaml
+++ b/tasks/notify-slack-on-failure/notify-slack-on-failure.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: notify-slack-on-failure
+spec:
+  description: >-
+    Sends an error message to Slack using postMessage API if managed pipelines fail
+  params:
+    - name: secretName
+      description: Name of secret which contains authentication token for app
+    - name: secretKeyName
+      description: Name of key within secret which contains webhook URL
+    - name: release
+      description: Namespaced name of release - should be in format "namespace/name"
+  volumes:
+    - name: slack-token
+      secret:
+        secretName: $(params.secretName)
+        optional: true
+  steps:
+    - name: notify-failure
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      volumeMounts:
+        - name: slack-token
+          mountPath: "/etc/secrets"
+          readOnly: true
+      env:
+        - name: KEYNAME
+          value: $(params.secretKeyName)
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+
+        if [ -z "${KEYNAME}" ] ; then
+          echo "No secret key name provided via the 'secretKeyName' pipeline parameter" \
+            "provided in the release-plan"
+          echo "No message will be sent to Slack"
+          exit
+        fi
+
+        if [ -f "/etc/secrets/${KEYNAME}" ]; then
+          WEBHOOK_URL=$(cat "/etc/secrets/${KEYNAME}")
+        else
+          echo "Error: Secret not defined properly. The key to use (${KEYNAME}) is defined in the 'secretKeyName'" \
+            "pipeline parameter provided in the release-plan but the Secret does not contain the key"
+          exit 1
+        fi
+
+        # check for release status and check if a managed pipeline failed
+        IFS='/' read -r RELEASE_NAMESPACE RELEASE_NAME <<< "$(params.release)"
+        RELEASECONDITIONS=$(kubectl get release "$RELEASE_NAME" -n "$RELEASE_NAMESPACE" \
+          -o jsonpath='{.status.conditions}' | jq '.[] | select(.type == "ManagedPipelineProcessed")')
+        
+        RELEASESTATUS=$(jq -r '.reason' <<< "$RELEASECONDITIONS")
+
+        if [[ "$RELEASESTATUS" == *"Failed"* ]]; then
+          MESSAGE=$(jq -r '.message' <<< "$RELEASECONDITIONS" | awk NF)
+          
+          # need 3 back-ticks around message for code-block
+          MESSAGE=$(echo -n "Managed pipelines failed: \`\`\`$MESSAGE\`\`\`" | jq -Rsa)
+          
+          cat > /tmp/payload.json << EOF
+        {"text": $MESSAGE}
+        EOF
+          # line above needs to be missing indentation
+
+          curl  -H "Content-type: application/json" --data-binary "@/tmp/payload.json"  \
+            "${WEBHOOK_URL}"
+        else
+          echo "All pipelines succeeded."
+        fi

--- a/tasks/notify-slack-on-failure/tests/mocks.sh
+++ b/tasks/notify-slack-on-failure/tests/mocks.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+
+# SC2016 - "Expressions don't expand in single quotes, use double quotes for that." 
+# is disabled because line 26 is checking for backticks, so single quotes are being
+# used to prevent ```SAMPLE ERROR MESSAGE``` from being expanded
+
+# shellcheck disable=SC2016
+set -eux
+
+# mocks to be injected into task step scripts
+
+function curl() {
+  echo Mock curl called with: $*
+  echo $* >> /tmp/mock_curl.txt
+
+  if [[ "$*" != "-H Content-type: application/json --data-binary @/tmp/payload.json ABCDEF"* ]]
+  then
+    echo Error: Unexpected call
+    exit 1
+  fi
+
+  # no workspaces to pass information along, but there's only one test that actually uses curl.
+  # if any other test manages to use curl, release is set to 'ns/success' in all other tests
+  # so they won't reproduce the error message and the test will fail
+  if [ "$(cat /tmp/payload.json)" != \
+    '{"text": "Managed pipelines failed: ```SAMPLE ERROR MESSAGE```"}' ]; then
+    echo Error: unexpected message
+    cat /tmp/payload.json
+    exit 1
+  fi
+
+  # makes sure curl is not called multiple times on test-notify-slack-release-failure.yaml
+  if [ "$(wc -l < /tmp/mock_curl.txt)" != 1 ]; then
+    echo Error: curl was expected to be called 1 times. Actual calls:
+    cat /tmp/mock_curl.txt
+    exit 1
+  fi
+}
+
+function kubectl() {
+  if [[ "$*" == *"release"* ]]
+  then
+    if [[ "$*" == *fail* ]]
+    then
+      cat > /tmp/mock-release.json <<EOF
+      {
+      "apiVersion": "appstudio.redhat.com/v1alpha1",
+      "kind": "Release",
+      "metadata": {
+          "name": "my-release"
+      },
+      "status": {
+          "conditions": [
+          {
+              "message": "",
+              "reason": "Succeeded",
+              "status": "True",
+              "type": "Validated"
+          },
+          {
+              "message": "",
+              "reason": "Skipped",
+              "status": "True",
+              "type": "TenantCollectorsPipelineProcessed"
+          },
+          {
+              "message": "",
+              "reason": "Skipped",
+              "status": "True",
+              "type": "ManagedCollectorsPipelineProcessed"
+          },
+          {
+              "message": "",
+              "reason": "Succeeded",
+              "status": "True",
+              "type": "ManagedPipelineProcessed"
+          },
+          {
+              "message": "",
+              "reason": "Succeeded",
+              "status": "True",
+              "type": "TenantPipelineProcessed"
+          },
+          {
+              "message": "",
+              "reason": "Succeeded",
+              "status": "True",
+              "type": "ManagedPipelineProcessed"
+          },
+          {
+              "message": "SAMPLE ERROR MESSAGE",
+              "reason": "Failed",
+              "status": "False",
+              "type": "ManagedPipelineProcessed"
+          },
+          {
+              "message": "",
+              "reason": "Succeeded",
+              "status": "True",
+              "type": "ManagedPipelineProcessed"
+          },
+          {
+              "message": "",
+              "reason": "Progressing",
+              "status": "False",
+              "type": "FinalPipelineProcessed"
+          }
+          ]
+      }
+      }
+EOF
+
+    elif [[ "$*" == *success* ]]
+    then
+      cat > /tmp/mock-release.json <<EOF
+      {
+      "apiVersion": "appstudio.redhat.com/v1alpha1",
+      "kind": "Release",
+      "metadata": {
+          "name": "my-release"
+      },
+      "status": {
+          "conditions": [
+          {
+              "message": "",
+              "reason": "Succeeded",
+              "status": "True",
+              "type": "Validated"
+          },
+          {
+              "message": "",
+              "reason": "Skipped",
+              "status": "True",
+              "type": "TenantCollectorsPipelineProcessed"
+          },
+          {
+              "message": "",
+              "reason": "Skipped",
+              "status": "True",
+              "type": "ManagedCollectorsPipelineProcessed"
+          },
+          {
+              "message": "",
+              "reason": "Succeeded",
+              "status": "True",
+              "type": "ManagedPipelineProcessed"
+          },
+          {
+              "message": "",
+              "reason": "Succeeded",
+              "status": "True",
+              "type": "TenantPipelineProcessed"
+          },
+          {
+              "message": "",
+              "reason": "Succeeded",
+              "status": "True",
+              "type": "ManagedPipelineProcessed"
+          },
+          {
+              "message": "",
+              "reason": "Progressing",
+              "status": "False",
+              "type": "FinalPipelineProcessed"
+          }
+          ]
+      }
+      }
+EOF
+    fi
+  fi
+
+  if [[ "$*" == *"-o jsonpath={.status.conditions}"* ]]; then
+    cat /tmp/mock-release.json | jq .status.conditions
+  else
+    cat /tmp/mock-release.json
+  fi
+
+}

--- a/tasks/notify-slack-on-failure/tests/pre-apply-task-hook.sh
+++ b/tasks/notify-slack-on-failure/tests/pre-apply-task-hook.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -x
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+# Create a dummy slack-notification-secret secret (and delete it first if it exists)
+kubectl delete secret my-secret --ignore-not-found
+
+kubectl create secret generic my-secret --from-literal=my-team=ABCDEF

--- a/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-key-not-found.yaml
+++ b/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-key-not-found.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-notify-slack-on-failure-key-not-found
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the notify-slack-on-failure task and verify that the task exits 
+    with an error when wrong secretKeyName is provided
+  tasks:
+    - name: run-task
+      taskRef:
+        name: notify-slack-on-failure
+      params:
+        - name: secretName
+          value: "my-secret"
+        - name: secretKeyName
+          value: "missing-key"
+        - name: release
+          value: "ns/success"

--- a/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-no-secret.yaml
+++ b/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-no-secret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-notify-slack-on-failure-no-secret
+spec:
+  description: |
+    Run the notify-slack-on-failure task and verify that the tasks exits when no secretName is provided
+  tasks:
+    - name: run-task
+      taskRef:
+        name: notify-slack-on-failure
+      params:
+        - name: secretName
+          value: "missing-secret"
+        - name: secretKeyName
+          value: ""
+        - name: release
+          value: "ns/success"

--- a/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-release-failure.yaml
+++ b/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-release-failure.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-notify-slack-on-failure-release-failure
+spec:
+  description: |
+    Run the notify-slack-on-failure task with a release that
+    has failed
+  tasks:
+    - name: run-task
+      taskRef:
+        name: notify-slack-on-failure
+      params:
+        - name: secretName
+          value: "my-secret"
+        - name: secretKeyName
+          value: "my-team"
+        - name: release
+          value: "ns/fail"

--- a/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-release-success.yaml
+++ b/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-release-success.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-notify-slack-on-failure-release-success
+spec:
+  description: |
+    Run the notify-slack-on-failure task with a release that
+    has succeeded
+  tasks:
+    - name: run-task
+      taskRef:
+        name: notify-slack-on-failure
+      params:
+        - name: secretName
+          value: "my-secret"
+        - name: secretKeyName
+          value: "my-team"
+        - name: release
+          value: "ns/success"

--- a/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-wrong-secret.yaml
+++ b/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-wrong-secret.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-notify-slack-on-failure-wrong-secret
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the notify-slack-on-failure task and verify that the task exits 
+    with an error when wrong secretName is provided
+  tasks:
+    - name: run-task
+      taskRef:
+        name: notify-slack-on-failure
+      params:
+        - name: secretName
+          value: "missing-secret"
+        - name: secretKeyName
+          value: "my-team"
+        - name: release
+          value: "ns/success"


### PR DESCRIPTION
Add notify-slack-on-failure task, along with a sample pipeline to run it. This task makes an app push a notification to slack when a managed pipeline fails.