### PR TITLE
chore(actions): bump tj-actions/changed-files to v45.0.6

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: install tkn
         uses: ./.github/actions/install-tkn
       - name: Get changed files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # v45.0.6
         id: changed-files
         with:
           files: |

--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Get changed dirs
         id: changed-dirs
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # v45.0.6
         with:
           files: |
             tasks/**


### PR DESCRIPTION

https://github.com/konflux-ci/community-catalog/security/dependabot/

* This version bump resolves a security issue where
  secrets could be exposed through action logs.
* Although the risk has been mitigated by the action
  this update aims to clear the security alert.
