### PR TITLE
feat(RELEASE-1486): add_samples_to_the_tenant_catalog

### DIFF
--- a/pipelines/notify-slack-on-failure/notify-slack-on-failure.yaml
+++ b/pipelines/notify-slack-on-failure/notify-slack-on-failure.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: notify-slack-on-failure
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release

--- a/pipelines/push-snapshot-to-quay/README.md
+++ b/pipelines/push-snapshot-to-quay/README.md
@@ -1,13 +1,14 @@
-# notify-slack-on-failure pipeline
+# push-snapshot-to-quay pipeline
 
-Sends an error message to Slack using postMessage API if managed pipelines fail.
+Tekton task to push snapshot images to quay.io using `cosign copy`. The destination for
+each image is taken from the '.spec.data.mapping' section of the release plan, in the form
+'.spec.data.mapping.components.repository', and '.spec.data.mapping.components.tags'.
 
 ## Parameters
 
 | Name            | Description                                                                     | Optional | Default Value                                       |
 |-----------------|---------------------------------------------------------------------------------|----------|-----------------------------------------------------|
-| secretName      | Name of secret which contains authentication token for app                      | No       | -                                                   |
-| secretKeyName   | Name of key within secret which contains webhook URL                            | No       | -                                                   |
-| release         | Namespaced name of release - should be in format "namespace/name"               | No       | -                                                   |
+| releasePlan     | Namespaced name of release plan - should be in format "namespace/name"          | No       | -                                                   |
+| snapshot        | Namespaced name of snapshot - should be in format "namespace/name"              | No       | -                                                   |
 | taskGitUrl      | The url to the git repo where the community-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/community-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used                                  | No       | -                                                   |

--- a/pipelines/push-snapshot-to-quay/push-snapshot-to-quay.yaml
+++ b/pipelines/push-snapshot-to-quay/push-snapshot-to-quay.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: push-snapshot-to-quay
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+spec:
+  description: >-
+    Tekton task to push snapshot images to quay.io using `cosign copy`. The destination for
+    each image is taken from the '.spec.data.mapping' section of the release plan, in the form
+    '.spec.data.mapping.components.repository', and '.spec.data.mapping.components.tags'.
+  params:
+    - name: releasePlan
+      description: Namespaced name of release plan - should be in format "namespace/name"
+      type: string
+    - name: snapshot
+      description: Namespaced name of snapshot - should be in format "namespace/name"
+      type: string
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the community-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/community-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  tasks:
+    - name: push-snapshot-to-quay
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
+      params:
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: releasePlan
+          value: $(params.releasePlan)

--- a/tasks/notify-slack-on-failure/README.md
+++ b/tasks/notify-slack-on-failure/README.md
@@ -4,8 +4,8 @@ Tekton task that sends an error message to Slack using postMessage API if manage
 
 ## Parameters
 
-| Name                                | Description                                                                                                                | Optional   | Default value                                             |
-|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------|------------|-----------------------------------------------------------|
-| secretName                          | Name of secret which contains authentication token for app                                                                 | No         | -                                                         |
-| secretKeyName                       | Name of key within secret which contains webhook URL                                                                       | No         | -                                                         |
-| release                             | Namespaced name of release - should be in format "namespace/name"                                                          | No         | -                                                         |
+| Name          | Description                                                       | Optional | Default Value |
+|---------------|-------------------------------------------------------------------|----------|---------------|
+| secretName    | Name of secret which contains authentication token for app        | No       | -             |
+| secretKeyName | Name of key within secret which contains webhook URL              | No       | -             |
+| release       | Namespaced name of release - should be in format "namespace/name" | No       | -             |

--- a/tasks/notify-slack-on-failure/notify-slack-on-failure.yaml
+++ b/tasks/notify-slack-on-failure/notify-slack-on-failure.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: notify-slack-on-failure
+  labels:
+    app.kubernetes.io/version: "0.1.0"
 spec:
   description: >-
     Sends an error message to Slack using postMessage API if managed pipelines fail

--- a/tasks/push-snapshot-to-quay/README.md
+++ b/tasks/push-snapshot-to-quay/README.md
@@ -1,0 +1,12 @@
+# push-snapshot-to-quay
+
+Tekton task to push snapshot images to quay.io using `cosign copy`. The destination for 
+each image is taken from the '.spec.data.mapping' section of the release plan, in the form
+'.spec.data.mapping.components.repository', and '.spec.data.mapping.components.tags'.
+
+## Parameters
+
+| Name        | Description                                                            | Optional | Default Value |
+|-------------|------------------------------------------------------------------------|----------|---------------|
+| releasePlan | Namespaced name of release plan - should be in format "namespace/name" | No       | -             |
+| snapshot    | Namespaced name of snapshot - should be in format "namespace/name"     | No       | -             |

--- a/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
+++ b/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: push-snapshot-to-quay
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+spec:
+  description: >-
+    Tekton task to push snapshot images to quay.io using `cosign copy`. The destination for
+    each image is taken from the '.spec.data.mapping' section of the release plan, in the form
+    '.spec.data.mapping.components.repository', and '.spec.data.mapping.components.tags'.
+  params:
+    - name: releasePlan
+      description: Namespaced name of release plan - should be in format "namespace/name"
+      type: string
+    - name: snapshot
+      description: Namespaced name of snapshot - should be in format "namespace/name"
+      type: string
+  steps:
+    - name: push-snapshot-to-quay
+      image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+
+        push_image() { # Expected arguments are [name, containerImage, repository, tag]
+          # this task is intended to be used for quay.io
+          REGISTRY=quay.io
+
+          SOURCE_AUTH_FILE=$(mktemp)
+          SOURCE_REPO=${2%%@sha256:*}
+          select-oci-auth "$2" | jq -c \
+            '.auths."'"$SOURCE_REPO"'" = .auths."'"$REGISTRY"'" | del(.auths."'"$REGISTRY"'")' > "$SOURCE_AUTH_FILE"
+
+          DEST_AUTH_FILE=$(mktemp)
+          # the auth key will be modified to the full repository path, so that
+          # we can create a combined auth file with source and destination entries for `cosign copy` later
+          select-oci-auth "$3" | jq -c \
+            '.auths."'"$3"'" = .auths."'"$REGISTRY"'" | del(.auths."'"$REGISTRY"'")' > "$DEST_AUTH_FILE"
+
+          DESTINATION_DIGEST=$(oras resolve --registry-config "$DEST_AUTH_FILE" "$3:$4" || true)
+          ORIGIN_DIGEST=$(oras resolve --registry-config "$SOURCE_AUTH_FILE" "$2")
+
+          if [[ "$DESTINATION_DIGEST" != "$ORIGIN_DIGEST" || -z "$DESTINATION_DIGEST" ]]; then
+            # Create a combined auth file to enable partial oci matches to work
+            DOCKER_CONFIG="$(mktemp -d)"
+            export DOCKER_CONFIG
+
+            # SC2128 - "Expanding an array without an index only gives the element in the index 0."
+            # is disabled because "$item" on the next line should only have one element, so there 
+            # is no need to get any index other than 0.
+
+            # shellcheck disable=SC2128
+            jq -s 'reduce .[] as $item ({}; . * $item)' \
+              "$SOURCE_AUTH_FILE" "$DEST_AUTH_FILE" > "$DOCKER_CONFIG"/config.json
+
+            cosign copy -f "$2" "$3:$4"
+
+            echo "Pushed image $2 to repository $3:$4"
+          else
+            echo "Component push skipped (source digest exists at destination): $1 $2"
+          fi
+
+        }
+
+        IFS='/' read -r "SNAPSHOT_NAMESPACE" "SNAPSHOT_NAME" <<< "$(params.snapshot)"
+        SNAPSHOT_SPEC=$(kubectl get snapshot "$SNAPSHOT_NAME" -n "$SNAPSHOT_NAMESPACE" \
+          -o jsonpath='{.spec}')
+
+        IFS='/' read -r "RP_NAMESPACE" "RP_NAME" <<< "$(params.releasePlan)"
+        RP_DATA=$(kubectl get releaseplan "$RP_NAME" -n "$RP_NAMESPACE" \
+          -o jsonpath='{.spec.data.mapping}')
+
+        NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_SPEC")
+
+        if [[ $NUM_COMPONENTS == 0 ]]; then
+          echo "No components in snapshot. There needs to be at least one component" \
+            "in the snapshot for this task to run."
+          exit 1
+        fi
+
+        for ((i = 0; i < NUM_COMPONENTS; i++)); do
+
+          COMPONENT=$(echo -n "$SNAPSHOT_SPEC" | jq -c --argjson i "$i" '.components[$i]')
+          COMPONENT_DESTINATION=$(echo -n "$RP_DATA" | jq -c --argjson i "$i" '.components[$i]')
+          
+          if [[ "$COMPONENT_DESTINATION" == "null" ]]; then
+            echo "No mappings left in release plan for components - Skipping remaining components."
+            break
+          fi
+
+          NAME=$(jq -r '.name' <<< "$COMPONENT")
+          CONTAINER_IMAGE=$(jq -r '.containerImage' <<< "$COMPONENT")
+          REPOSITORY=$(jq -r '.repository' <<< "$COMPONENT_DESTINATION")
+          IMAGE_TAGS=$(jq -r '.tags' <<< "$COMPONENT_DESTINATION")
+
+          for TAG in $(jq -r '.[]' <<< "$IMAGE_TAGS"); do
+            push_image "$NAME" "$CONTAINER_IMAGE" "$REPOSITORY" "$TAG"
+          done
+
+        done

--- a/tasks/push-snapshot-to-quay/tests/mocks.sh
+++ b/tasks/push-snapshot-to-quay/tests/mocks.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -eux
+
+# mocks to be injected into task step scripts
+
+function cosign() {
+  # mock cosign failing for the no-permission test
+  if [[ "$*" == "copy -f quay.io/no-permission:tag "*":"* ]]
+  then
+    echo Invalid credentials for quay.io/no-permission:tag
+    return 1
+  fi
+
+  if [[ "$*" != "copy -f "*":"*" "*":"* ]]
+  then
+    echo Error: Unexpected call
+    exit 1
+  fi
+}
+
+function kubectl() {
+  if [[ "$*" == *"snapshot"* ]]
+  then
+    if [[ "$3" == "nopermission" ]]; then
+      TEST_IMAGE="quay.io/no-permission:tag"
+    elif [[ "$3" == "skip-image" ]]; then
+      TEST_IMAGE="quay.io/valid-repo:skip-image"
+    else
+      TEST_IMAGE="quay.io/valid-repo:tag"
+    fi
+
+    EXTRA_COMPONENTS=""
+    if [[ "$3" == "multiple" ]]; then
+      EXTRA_COMPONENTS=',
+      {
+        "containerImage": "quay.io/valid-repo:tag2",
+        "name": "test-image2"
+      },
+      {
+        "containerImage": "quay.io/valid-repo:skip-image",
+        "name": "test-image3"
+      },
+      {
+        "containerImage": "quay.io/valid-repo2:skip-image",
+        "name": "test-image4"
+      }'
+    fi
+
+    if [[ "$3" == "empty" ]]; then
+      cat > /tmp/mock-snapshot.json <<EOF
+      {
+        "apiVersion": "appstudio.redhat.com/v1alpha1",
+        "kind": "Snapshot",
+        "metadata": {
+          "name": "snapshot",
+          "namespace": "ns2"
+        },
+        "spec": {
+          "application": "demo",
+          "artifacts": {},
+          "components": []
+        }
+      }
+EOF
+    else
+      cat > /tmp/mock-snapshot.json <<EOF
+      {
+        "apiVersion": "appstudio.redhat.com/v1alpha1",
+        "kind": "Snapshot",
+        "metadata": {
+          "name": "snapshot",
+          "namespace": "ns2"
+        },
+        "spec": {
+          "application": "demo",
+          "artifacts": {},
+          "components": [
+            {
+              "containerImage": "$TEST_IMAGE",
+              "name": "test-image"
+            }$EXTRA_COMPONENTS
+          ]
+        }
+      }
+EOF
+    fi
+
+    if [[ "$*" == *"jsonpath={.spec}"* ]]; then
+      cat /tmp/mock-snapshot.json | jq .spec
+    else
+      cat /tmp/mock-snapshot.json
+    fi
+
+  elif [[ "$*" == *"releaseplan"* ]]
+  then
+    if [[ "$3" == "skip-image" ]]; then
+      TEST_REPO="quay.io/valid-repo2"
+    else
+      TEST_REPO="quay.io/default-repo2"
+    fi
+
+    EXTRA_COMPONENT_DESTINATIONS=""
+    if [[ "$3" == "multiple" ]]; then
+      EXTRA_COMPONENT_DESTINATIONS=',
+      {
+        "repository": "quay.io/default-repo3",
+        "tags": [
+          "testtag",
+          "testtag2"
+        ]
+      },
+      {
+        "repository": "quay.io/default-repo2",
+        "tags": [
+          "skip-image"
+        ]
+      },
+      {
+        "repository": "quay.io/default-repo2",
+        "tags": [
+          "skip-image",
+          "testtag"
+        ]
+      }'
+    fi
+
+    cat > /tmp/mock-releaseplan.json <<EOF
+    {
+      "apiVersion": "appstudio.redhat.com/v1alpha1",
+      "kind": "ReleasePlan",
+      "metadata": {
+        "name": "releaseplan",
+        "namespace": "ns2"
+      },
+      "spec": {
+        "application": "demo",
+        "data": {
+          "mapping": {
+            "components": [
+              {
+                "repository": "$TEST_REPO",
+                "tags": [
+                  "testtag"
+                ]
+              }$EXTRA_COMPONENT_DESTINATIONS
+            ]
+          }
+        }
+      }
+    }
+EOF
+
+    if [[ "$*" == *"jsonpath={.spec.data.mapping}"* ]]; then
+      cat /tmp/mock-releaseplan.json | jq .spec.data.mapping
+    else
+      cat /tmp/mock-releaseplan.json
+    fi
+  fi
+
+}
+
+function oras() {
+  if [[ "$*" == "resolve --registry-config "*" "* ]]; then
+    if [[ "$*" =~ "--platform" && "$4" =~ ".src" ]]; then
+      echo "Error: .src images should not use --platform" >&2
+      exit 1
+    fi
+    if [[ "$4" == *skip-image* ]]; then
+      echo "sha256:111111"
+    else
+      # echo the shasum computed from the pull spec so the task knows if two images are the same
+      echo -n "sha256:"
+      echo $4 | sha256sum | cut -d ' ' -f 1
+    fi
+    return
+  else
+    echo Mock oras called with: $*
+    echo Error: Unexpected call
+    exit 1
+  fi
+}

--- a/tasks/push-snapshot-to-quay/tests/pre-apply-task-hook.sh
+++ b/tasks/push-snapshot-to-quay/tests/pre-apply-task-hook.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -x
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-multiple-components.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-multiple-components.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-to-quay-multiple-components
+spec:
+  description: |
+    Run the push-snapshot-to-quay task with multiple components
+    and check that the task succeeds
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-snapshot-to-quay
+      params:
+        - name: releasePlan
+          value: "ns/multiple"
+        - name: snapshot
+          value: "ns/multiple"

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-no-components.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-no-components.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-to-quay-no-components
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the push-snapshot-to-quay task and check that the task 
+    fails when there are no components present in the snapshot
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-snapshot-to-quay
+      params:
+        - name: releasePlan
+          value: "ns/releasePlan"
+        - name: snapshot
+          value: "ns/empty"

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-no-permission.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-no-permission.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-to-quay-no-permission
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the push-snapshot-to-quay task without credentials to access a repository
+    and check that the task fails
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-snapshot-to-quay
+      params:
+        - name: releasePlan
+          value: "ns/releasePlan"
+        - name: snapshot
+          value: "ns/nopermission"

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-skip-existing.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-skip-existing.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-to-quay-skip-existing
+spec:
+  description: |
+    Run the push-snapshot-to-quay task with source and destination
+    images that have the same SHA hash and check that the task succeeds
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-snapshot-to-quay
+      params:
+        - name: releasePlan
+          value: "ns/skip-image"
+        - name: snapshot
+          value: "ns/skip-image"

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-success.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-success.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-to-quay-success
+spec:
+  description: |
+    Run the push-snapshot-to-quay task and check that the task succeeds
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-snapshot-to-quay
+      params:
+        - name: releasePlan
+          value: "ns/releasePlan"
+        - name: snapshot
+          value: "ns/snapshot"

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-unequal-component-amounts.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-unequal-component-amounts.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-to-quay-unequal-component-amounts
+spec:
+  description: |
+    Run the push-snapshot-to-quay task and check that the task 
+    succeeds with a different number of components in the 
+    release plan and snapshot
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-snapshot-to-quay
+      params:
+        - name: releasePlan
+          value: "ns/releasePlan"
+        - name: snapshot
+          value: "ns/multiple"


### PR DESCRIPTION
Add push-snapshot-to-quay task, along with a pipeline to run it. This task pushes snapshot images to quay.io
using `cosign copy`.