### PR TITLE
feat(RELEASE-1487): force contributions to contain valid owners file

### DIFF
--- a/.github/scripts/check_owners.sh
+++ b/.github/scripts/check_owners.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# This script will check for an OWNERS file in all task and pipeline 
+# directories provided either via DIRECTORIES env var, or as 
+# arguments when running the script.
+#
+# Examples of usage:
+# export DIRECTORIES="mydir/tasks/apply-mapping some/other/dir"
+# ./check_owners.sh
+#
+# or
+#
+# ./check_owners.sh mydir/tasks/apply-mapping some/other/dir
+
+if [ $# -gt 0 ]; then
+  DIRECTORIES=$@
+fi
+
+if [ -z "${DIRECTORIES}" ]; then
+  echo Error: No directories as argument.
+  echo Usage:
+  echo "$0 [item1] [item2] [...]"
+  exit 1
+fi
+
+TEAM_NAME=release-service-maintainers
+
+# check every item is a directory
+for DIR in $DIRECTORIES; do
+  if [[ -d "$DIR" ]]; then
+    true
+  else
+    echo "Error: Not a directory: $DIR"
+    exit 1
+  fi
+
+  OWNERS=${DIR}/OWNERS
+
+  if [ ! -f $OWNERS ]; then
+    echo Error: OWNERS file does not exist: $SHORT_DIR
+    exit 1
+  fi
+
+  REGEX="(\s)$TEAM_NAME($|\s)"
+
+  if [[ $(cat $OWNERS) =~ $REGEX ]]; then
+    echo "Error: $TEAM_NAME cannot be" \
+      "included as a code owner."
+    exit 1 
+  fi
+
+  echo "$OWNERS exists and does not contain $TEAM_NAME"
+
+done

--- a/.github/workflows/check_owners.yaml
+++ b/.github/workflows/check_owners.yaml
@@ -1,0 +1,34 @@
+---
+name: Check owners
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+jobs:
+  run-tekton-task-tests:
+    name: Check owners
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Get changed dirs
+        id: changed-dirs
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # v45.0.6
+        with:
+          files: |
+            tasks/**
+            pipelines/**
+          dir_names: "true"
+          dir_names_max_depth: "2"
+      - name: Show changed dirs
+        run: |
+          echo ${{ steps.changed-dirs.outputs.all_changed_files }}
+      - name: Check owners
+        if: |
+          steps.changed-dirs.outputs.any_changed == 'true'
+        run: .github/scripts/check_owners.sh
+        env:
+          DIRECTORIES: >-
+            ${{ steps.changed-dirs.outputs.all_changed_files }}

--- a/pipelines/notify-slack-on-failure/OWNERS
+++ b/pipelines/notify-slack-on-failure/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - Paul123111

--- a/pipelines/push-snapshot-to-quay/OWNERS
+++ b/pipelines/push-snapshot-to-quay/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - Paul123111

--- a/tasks/notify-slack-on-failure/OWNERS
+++ b/tasks/notify-slack-on-failure/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - Paul123111

--- a/tasks/push-snapshot-to-quay/OWNERS
+++ b/tasks/push-snapshot-to-quay/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - Paul123111


### PR DESCRIPTION
Add GitHub workflow that checks for OWNERS files in each task/pipeline directory, and ensures the release-service-maintainers team is not included in any of the OWNERS files.

NOTE: The OWNERS files will not do anything yet, I will configure openshift-ci to use these files after this PR is merged.