### PR TITLE
feat(RELEASE-1487): force contributions to contain valid owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+  - johnbieren
+  - mmalina
+  - jinqi7
+  - scoheb
+  - davidmogar
+  - happybhati
+  - FilipNikolovski
+  - theflockers
+  - seanconroy2021


### PR DESCRIPTION
Add owners file to root directory so members of `konflux-ci/release-service-maintainers` are selected for review when a new task/pipeline is added.