### PR TITLE
feat: add support for only pushing snapshot after successful managed

### DIFF
--- a/pipelines/push-snapshot-to-quay/README.md
+++ b/pipelines/push-snapshot-to-quay/README.md
@@ -4,11 +4,16 @@ Tekton task to push snapshot images to quay.io using `cosign copy`. The destinat
 each image is taken from the '.spec.data.mapping' section of the release plan, in the form
 '.spec.data.mapping.components.repository', and '.spec.data.mapping.components.tags'.
 
+If `requireSuccessfulManagedRelease` is "true", the snapshot will only be pushed if it
+contains a status indicating that a managed pipeline has successfully completed.
+
 ## Parameters
 
 | Name            | Description                                                                     | Optional | Default Value                                       |
 |-----------------|---------------------------------------------------------------------------------|----------|-----------------------------------------------------|
 | releasePlan     | Namespaced name of release plan - should be in format "namespace/name"          | No       | -                                                   |
 | snapshot        | Namespaced name of snapshot - should be in format "namespace/name"              | No       | -                                                   |
+| release         | Namespaced name of release - should be in format "namespace/name"               | No       | -                                                   |
+| requireSuccessfulManagedRelease | Only push if the managed release status is successful ("true"/"false") | Yes      | "false"        |
 | taskGitUrl      | The url to the git repo where the community-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/community-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used                                  | No       | -                                                   |

--- a/pipelines/push-snapshot-to-quay/push-snapshot-to-quay.yaml
+++ b/pipelines/push-snapshot-to-quay/push-snapshot-to-quay.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-snapshot-to-quay
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.2.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
 spec:
@@ -12,6 +12,9 @@ spec:
     Tekton task to push snapshot images to quay.io using `cosign copy`. The destination for
     each image is taken from the '.spec.data.mapping' section of the release plan, in the form
     '.spec.data.mapping.components.repository', and '.spec.data.mapping.components.tags'.
+    
+    If `requireSuccessfulManagedRelease` is "true", the snapshot will only be pushed if it
+    contains a status indicating that a managed pipeline has successfully completed.
   params:
     - name: releasePlan
       description: Namespaced name of release plan - should be in format "namespace/name"
@@ -26,6 +29,13 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
+    - name: release
+      description: Namespaced name of release - should be in format "namespace/name"
+      type: string
+    - name: requireSuccessfulManagedRelease
+      description: Only push if the managed release status is successful
+      type: string
+      default: "false"
   tasks:
     - name: push-snapshot-to-quay
       taskRef:
@@ -42,3 +52,7 @@ spec:
           value: $(params.snapshot)
         - name: releasePlan
           value: $(params.releasePlan)
+        - name: release
+          value: $(params.release)
+        - name: requireSuccessfulManagedRelease
+          value: $(params.requireSuccessfulManagedRelease)

--- a/tasks/push-snapshot-to-quay/README.md
+++ b/tasks/push-snapshot-to-quay/README.md
@@ -4,9 +4,14 @@ Tekton task to push snapshot images to quay.io using `cosign copy`. The destinat
 each image is taken from the '.spec.data.mapping' section of the release plan, in the form
 '.spec.data.mapping.components.repository', and '.spec.data.mapping.components.tags'.
 
+If `requireSuccessfulManagedRelease` is "true", the snapshot will only be pushed if it
+contains a status indicating that a managed pipeline has successfully completed.
+
 ## Parameters
 
 | Name        | Description                                                            | Optional | Default Value |
 |-------------|------------------------------------------------------------------------|----------|---------------|
+| release     | Namespaced name of release - should be in format "namespace/name"      | No       | -             |
 | releasePlan | Namespaced name of release plan - should be in format "namespace/name" | No       | -             |
+| requireSuccessfulManagedRelease | Only push if the managed release status is successful ("true"/"false") | Yes      | "false"        |
 | snapshot    | Namespaced name of snapshot - should be in format "namespace/name"     | No       | -             |

--- a/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
+++ b/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
@@ -4,20 +4,57 @@ kind: Task
 metadata:
   name: push-snapshot-to-quay
   labels:
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: "0.2.0"
 spec:
   description: >-
     Tekton task to push snapshot images to quay.io using `cosign copy`. The destination for
     each image is taken from the '.spec.data.mapping' section of the release plan, in the form
     '.spec.data.mapping.components.repository', and '.spec.data.mapping.components.tags'.
+    
+    If `requireSuccessfulManagedRelease` is "true", the snapshot will only be pushed if it
+    contains a status indicating that a managed pipeline has successfully completed.
   params:
+    - name: release
+      description: Namespaced name of release - should be in format "namespace/name"
+      type: string
     - name: releasePlan
       description: Namespaced name of release plan - should be in format "namespace/name"
+      type: string
+    - name: requireSuccessfulManagedRelease
+      description: Only push if the managed release status is successful
       type: string
     - name: snapshot
       description: Namespaced name of snapshot - should be in format "namespace/name"
       type: string
   steps:
+    - name: check-release-status
+      image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+
+        # Only check release status if it will be used to determine push
+        if [[ "$(params.requireSuccessfulManagedRelease)" != "true" ]]; then
+          echo "No release validation required, skipping check-release-status step."
+          exit 0
+        fi
+
+        # check for release status and check if a managed pipeline failed
+        IFS='/' read -r RELEASE_NAMESPACE RELEASE_NAME <<< "$(params.release)"
+        RELEASECONDITIONS=$(kubectl get release "$RELEASE_NAME" -n "$RELEASE_NAMESPACE" \
+          -o jsonpath='{.status.conditions}')
+        if [ -z "$RELEASECONDITIONS" ]; then
+          echo "No release conditions found for $RELEASE_NAME in namespace $RELEASE_NAMESPACE"
+          exit 1
+        fi
+        RELEASECONDITION=$(echo "$RELEASECONDITIONS" | jq '.[] | select(.type == "ManagedPipelineProcessed")')
+        RELEASESTATUS=$(jq -r '.reason' <<< "$RELEASECONDITION")
+        echo "Release status: $RELEASESTATUS"
+
+        if [[ "$RELEASESTATUS" != *"Succeeded"* ]]; then
+          echo "Release did not succeed, stopping snapshot push"
+          exit 1
+        fi
     - name: push-snapshot-to-quay
       image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
       script: |

--- a/tasks/push-snapshot-to-quay/tests/mocks.sh
+++ b/tasks/push-snapshot-to-quay/tests/mocks.sh
@@ -155,6 +155,80 @@ EOF
     else
       cat /tmp/mock-releaseplan.json
     fi
+  elif [[ "$*" == *"release "* ]]
+  then
+    # Simulate release status for release lookups
+    RELEASE_NAMESPACE="$2"
+    RELEASE_NAME="$3"
+    if [[ "$3" == "fail" ]]; then
+      cat > /tmp/mock-release.json <<EOF
+      {
+        "apiVersion": "appstudio.redhat.com/v1alpha1",
+        "kind": "Release",
+        "metadata": {
+          "name": "fail",
+          "namespace": "$2"
+        },
+        "status": {
+          "conditions": [
+            {
+              "message": "Simulated failure message",
+              "reason": "Failed",
+              "status": "False",
+              "type": "ManagedPipelineProcessed"
+            }
+          ]
+        }
+      }
+EOF
+    elif [[ "$3" == "success" ]]; then
+      cat > /tmp/mock-release.json <<EOF
+      {
+        "apiVersion": "appstudio.redhat.com/v1alpha1",
+        "kind": "Release",
+        "metadata": {
+          "name": "success",
+          "namespace": "$2"
+        },
+        "status": {
+          "conditions": [
+            {
+              "message": "",
+              "reason": "Succeeded",
+              "status": "True",
+              "type": "ManagedPipelineProcessed"
+            }
+          ]
+        }
+      }
+EOF
+    else
+      cat > /tmp/mock-release.json <<EOF
+      {
+        "apiVersion": "appstudio.redhat.com/v1alpha1",
+        "kind": "Release",
+        "metadata": {
+          "name": "$3",
+          "namespace": "$2"
+        },
+        "status": {
+          "conditions": [
+            {
+              "message": "",
+              "reason": "Succeeded",
+              "status": "True",
+              "type": "ManagedPipelineProcessed"
+            }
+          ]
+        }
+      }
+EOF
+    fi
+    if [[ "$*" == *"jsonpath={.status.conditions}"* ]]; then
+      cat /tmp/mock-release.json | jq '.status.conditions'
+    else
+      cat /tmp/mock-release.json
+    fi
   fi
 
 }

--- a/tasks/push-snapshot-to-quay/tests/pre-apply-task-hook.sh
+++ b/tasks/push-snapshot-to-quay/tests/pre-apply-task-hook.sh
@@ -4,5 +4,7 @@ set -x
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-# Add mocks to the beginning of task step script
-yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+# Add mocks to the beginning of all task step scripts (step 0 and 1)
+for i in 0 1; do
+  yq -i ".spec.steps[$i].script = load_str(\"$SCRIPT_DIR/mocks.sh\") + .spec.steps[$i].script" "$TASK_PATH"
+done

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-multiple-components.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-multiple-components.yaml
@@ -16,3 +16,7 @@ spec:
           value: "ns/multiple"
         - name: snapshot
           value: "ns/multiple"
+        - name: release
+          value: "ns/multiple-release"
+        - name: requireSuccessfulManagedRelease
+          value: "false"

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-no-components.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-no-components.yaml
@@ -18,3 +18,7 @@ spec:
           value: "ns/releasePlan"
         - name: snapshot
           value: "ns/empty"
+        - name: release
+          value: "ns/empty-release"
+        - name: requireSuccessfulManagedRelease
+          value: "false"

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-no-permission.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-no-permission.yaml
@@ -18,3 +18,7 @@ spec:
           value: "ns/releasePlan"
         - name: snapshot
           value: "ns/nopermission"
+        - name: release
+          value: "ns/nopermission-release"
+        - name: requireSuccessfulManagedRelease
+          value: "false"

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-release-failed-no-require-success.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-release-failed-no-require-success.yaml
@@ -2,10 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-snapshot-to-quay-success
+  name: test-push-snapshot-to-quay-release-failed-no-require-success
 spec:
   description: |
-    Run the push-snapshot-to-quay task and check that the task succeeds
+    Run the push-snapshot-to-quay task with a release param that refers to a failed release,
+    but do not require a successful release. The task should succeed (not block on failure).
   tasks:
     - name: run-task
       taskRef:
@@ -16,6 +17,6 @@ spec:
         - name: snapshot
           value: "ns/snapshot"
         - name: release
-          value: "ns/snapshot-release"
+          value: "ns/fail"
         - name: requireSuccessfulManagedRelease
           value: "false"

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-release-failed.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-release-failed.yaml
@@ -2,10 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-snapshot-to-quay-success
+  name: test-push-snapshot-to-quay-release-failed
+  annotations:
+    test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the push-snapshot-to-quay task and check that the task succeeds
+    Run the push-snapshot-to-quay task with a release param that refers to a failed release. The task should fail.
   tasks:
     - name: run-task
       taskRef:
@@ -16,6 +18,6 @@ spec:
         - name: snapshot
           value: "ns/snapshot"
         - name: release
-          value: "ns/snapshot-release"
+          value: "ns/fail"
         - name: requireSuccessfulManagedRelease
-          value: "false"
+          value: "true"

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-release-success.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-release-success.yaml
@@ -2,10 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-push-snapshot-to-quay-success
+  name: test-push-snapshot-to-quay-release-success
 spec:
   description: |
-    Run the push-snapshot-to-quay task and check that the task succeeds
+    Run the push-snapshot-to-quay task with a release param that refers to a successful release.
+    The task should succeed.
   tasks:
     - name: run-task
       taskRef:
@@ -16,6 +17,6 @@ spec:
         - name: snapshot
           value: "ns/snapshot"
         - name: release
-          value: "ns/snapshot-release"
+          value: "ns/success"
         - name: requireSuccessfulManagedRelease
-          value: "false"
+          value: "true"

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-skip-existing.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-skip-existing.yaml
@@ -16,3 +16,7 @@ spec:
           value: "ns/skip-image"
         - name: snapshot
           value: "ns/skip-image"
+        - name: release
+          value: "ns/skip-image-release"
+        - name: requireSuccessfulManagedRelease
+          value: "false"

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-unequal-component-amounts.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-unequal-component-amounts.yaml
@@ -17,3 +17,7 @@ spec:
           value: "ns/releasePlan"
         - name: snapshot
           value: "ns/multiple"
+        - name: release
+          value: "ns/unequal-release"
+        - name: requireSuccessfulManagedRelease
+          value: "false"


### PR DESCRIPTION
release

Users might only want to push snapshots if the managed pipelines succeed. If, for example, a conforma check fails on the managed pipeline, a tenant may not want to push the images for some QE team to pick them up for testing.

This PR adds an optional release parameter. If the parameter is specified, a snapshot will only be pushed if there is a successful managed release pipeline.

Assisted-by: CoPilot
Signed-off-by: arewm <arewm@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED