### PR TITLE
Fix component to mapping matching

### DIFF
--- a/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
+++ b/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
@@ -120,14 +120,14 @@ spec:
         for ((i = 0; i < NUM_COMPONENTS; i++)); do
 
           COMPONENT=$(echo -n "$SNAPSHOT_SPEC" | jq -c --argjson i "$i" '.components[$i]')
-          COMPONENT_DESTINATION=$(echo -n "$RP_DATA" | jq -c --argjson i "$i" '.components[$i]')
-          
-          if [[ "$COMPONENT_DESTINATION" == "null" ]]; then
-            echo "No mappings left in release plan for components - Skipping remaining components."
-            break
+          NAME=$(jq -r '.name' <<< "$COMPONENT")
+          COMPONENT_DESTINATION=$(echo -n "$RP_DATA" | jq -c --arg c "$NAME" '.components[] | select(.name == $c)')
+
+          if [[ "$COMPONENT_DESTINATION" == "" ]]; then
+            echo "No mapping for ${NAME}. Skipping."
+            continue
           fi
 
-          NAME=$(jq -r '.name' <<< "$COMPONENT")
           CONTAINER_IMAGE=$(jq -r '.containerImage' <<< "$COMPONENT")
           REPOSITORY=$(jq -r '.repository' <<< "$COMPONENT_DESTINATION")
           IMAGE_TAGS=$(jq -r '.tags' <<< "$COMPONENT_DESTINATION")

--- a/tasks/push-snapshot-to-quay/tests/mocks.sh
+++ b/tasks/push-snapshot-to-quay/tests/mocks.sh
@@ -103,6 +103,7 @@ EOF
     if [[ "$3" == "multiple" ]]; then
       EXTRA_COMPONENT_DESTINATIONS=',
       {
+        "name": "test-image2",
         "repository": "quay.io/default-repo3",
         "tags": [
           "testtag",
@@ -110,12 +111,14 @@ EOF
         ]
       },
       {
+        "name": "test-image3",
         "repository": "quay.io/default-repo2",
         "tags": [
           "skip-image"
         ]
       },
       {
+        "name": "test-image4",
         "repository": "quay.io/default-repo2",
         "tags": [
           "skip-image",
@@ -138,6 +141,7 @@ EOF
           "mapping": {
             "components": [
               {
+                "name": "test-image",
                 "repository": "$TEST_REPO",
                 "tags": [
                   "testtag"


### PR DESCRIPTION
The current implementation is assuming the order of the components on the `snapshot` and the RP `mapping` is identical. However this might not be the case. Modify the script to filter the mapping using the component name