### PR TITLE
chore: move internal-services update resources

### DIFF
--- a/pipelines/update-internal-services-manager/OWNERS
+++ b/pipelines/update-internal-services-manager/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+  - Paul123111
+  - johnbieren
+  - mmalina
+  - happybhati
+  - davidmogar
+  - theflockers
+  - seanconroy2021
+  - filipnikolovski

--- a/pipelines/update-internal-services-manager/README.md
+++ b/pipelines/update-internal-services-manager/README.md
@@ -1,0 +1,12 @@
+# update-internal-services-manager
+
+Tekton pipeline to update the internal-services manager yaml to the latest image in the
+hacbs-release/app-interface-deployments repository.
+
+## Parameters
+
+| Name         | Description                                                                                            | Optional | Default value |
+|--------------|--------------------------------------------------------------------------------------------------------|----------|---------------|
+| release      | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No       | -             |
+| repoUrl      | The repository where the internal-services manager files to update are                                 | No       | -             |
+| githubSecret | The secret containing a TOKEN key to authenticate with GitHub to the repoUrl                           | No       | -             |

--- a/pipelines/update-internal-services-manager/update-internal-services-manager.yaml
+++ b/pipelines/update-internal-services-manager/update-internal-services-manager.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: update-internal-services-manager
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "release, tenant"
+spec:
+  description: >-
+    Tekton pipeline to update the internal-services manager yaml to the latest image in the
+    hacbs-release/app-interface-deployments repository.
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: repoUrl
+      type: string
+      description: The repository where the internal-services manager files to update are
+    - name: githubSecret
+      type: string
+      description: The secret containing a TOKEN key to authenticate with GitHub to the repoUrl
+  tasks:
+    - name: get-git-sha-image-ref-from-release
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/community-catalog.git
+          - name: revision
+            value: development
+          - name: pathInRepo
+            value: tasks/get-git-sha-image-ref-from-release/get-git-sha-image-ref-from-release.yaml
+      params:
+        - name: release
+          value: $(params.release)
+    - name: update-staging-manager
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/community-catalog.git
+          - name: revision
+            value: development
+          - name: pathInRepo
+            value: tasks/update-manager-image-in-git/update-manager-image-in-git.yaml
+      params:
+        - name: mode
+          value: push
+        - name: repoBranch
+          value: main
+        - name: repoUrl
+          value: $(params.repoUrl)
+        - name: githubSecret
+          value: $(params.githubSecret)
+        - name: image
+          value: $(tasks.get-git-sha-image-ref-from-release.results.imageRef)
+    - name: update-production-manager
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/community-catalog.git
+          - name: revision
+            value: development
+          - name: pathInRepo
+            value: tasks/update-manager-image-in-git/update-manager-image-in-git.yaml
+      params:
+        - name: mode
+          value: pr
+        - name: repoBranch
+          value: stable
+        - name: repoUrl
+          value: $(params.repoUrl)
+        - name: githubSecret
+          value: $(params.githubSecret)
+        - name: image
+          value: $(tasks.get-git-sha-image-ref-from-release.results.imageRef)

--- a/tasks/get-git-sha-image-ref-from-release/OWNERS
+++ b/tasks/get-git-sha-image-ref-from-release/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+  - Paul123111
+  - johnbieren
+  - mmalina
+  - happybhati
+  - davidmogar
+  - theflockers
+  - seanconroy2021
+  - filipnikolovski

--- a/tasks/get-git-sha-image-ref-from-release/README.md
+++ b/tasks/get-git-sha-image-ref-from-release/README.md
@@ -1,0 +1,18 @@
+# get-git-sha-image-ref-from-release
+
+Tekton task to get the image reference containing the git sha tag from the Release artifacts.
+
+It finds the git sha by checking for the `pac.test.appstudio.openshift.io/sha` label on the Release CR.
+If it is not found, the task will fail with error.
+
+This task is only meant to work with Releases for one component. If the task finds there are more than one image
+in its artifacts, it will fail with error.
+
+Once it has the git sha, the task simply returns the image url from the artifacts that ends with it. This is
+done via the `imageRef` task result.
+
+## Parameters
+
+| Name    | Description                    | Optional | Default value |
+|---------|--------------------------------|----------|---------------|
+| release | Namespaced name of the Release | No       | -             |

--- a/tasks/get-git-sha-image-ref-from-release/get-git-sha-image-ref-from-release.yaml
+++ b/tasks/get-git-sha-image-ref-from-release/get-git-sha-image-ref-from-release.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: get-git-sha-image-ref-from-release
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "release, tenant"
+spec:
+  description: >-
+    Tekton task to output the imageRef stored in the Release artifacts that corresponds to the git sha tag.
+  params:
+    - name: release
+      type: string
+      description: The namespaced name of the Release
+  results:
+    - name: imageRef
+      type: string
+      description: The imageRef from the Release.Status.Artifacts that uses the git sha tag
+  steps:
+    - name: get-git-sha-image-ref-from-release
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      script: |
+        #!/usr/bin/env bash
+        set -euxo pipefail
+
+        IFS='/' read -r RELEASE_NAMESPACE RELEASE_NAME <<< "$(params.release)"
+
+        GIT_SHA=$(kubectl get release "$RELEASE_NAME" -n "$RELEASE_NAMESPACE" \
+          -o jsonpath='{.metadata.labels.pac\.test\.appstudio\.openshift\.io/sha}')
+        if [ -z "$GIT_SHA" ] ; then
+            echo "Error: git sha label from PaC not found in Release labels"
+            exit 1
+        fi
+
+        IMAGES=$(kubectl get release "$RELEASE_NAME" -n "$RELEASE_NAMESPACE" \
+          -o jsonpath='{.status.artifacts.images}')
+        if [ -z "$IMAGES" ] ; then
+            echo "Error: no images found in Release Status Artifacts"
+            exit 1
+        fi
+
+        if [ "$(jq 'length // 0' <<< "$IMAGES")" -ne 1 ] ; then
+            echo "Error: this task only supports Release CRs with one image in its artifacts."
+            echo "Found images: $IMAGES"
+            exit 1
+        fi
+
+        REF=$(jq -jr --arg sha "$GIT_SHA" '.[0].urls[] | select(test(".*" + $sha))' <<< "$IMAGES")
+        if [ -z "$REF" ] ; then
+            echo "Error: imageRef with git sha tag not found in Release artifacts"
+            exit 1
+        fi
+        echo -n "$REF" > "$(results.imageRef.path)"

--- a/tasks/get-git-sha-image-ref-from-release/tests/crd_rbac.yaml
+++ b/tasks/get-git-sha-image-ref-from-release/tests/crd_rbac.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pipeline-test-role
+  namespace: default
+rules:
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - internalrequests
+      - internalrequests/status
+      - releases
+      - releases/status
+      - releaseplans
+      - releaseplanadmissions
+      - releaseserviceconfigs
+      - snapshots
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - pipelineruns/status
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      -
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pipeline-test-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pipeline-test-role
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default

--- a/tasks/get-git-sha-image-ref-from-release/tests/pre-apply-task-hook.sh
+++ b/tasks/get-git-sha-image-ref-from-release/tests/pre-apply-task-hook.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Install the CRDs so we can create/get them
+install_appstudio_repo_crds () {
+    git clone https://github.com/$1/$2
+    pushd $2
+    kubectl create -f config/crd/bases
+    popd
+}
+
+if ! kubectl get crd snapshots.appstudio.redhat.com ; then
+    install_appstudio_repo_crds "redhat-appstudio" "application-api"
+fi
+
+if ! kubectl get crd releases.appstudio.redhat.com ; then
+    install_appstudio_repo_crds "konflux-ci" "internal-services"
+fi
+
+if ! kubectl get crd releases.appstudio.redhat.com ; then
+    install_appstudio_repo_crds "konflux-ci" "release-service"
+fi
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+kubectl apply -f "${SCRIPT_DIR}/crd_rbac.yaml"

--- a/tasks/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref-fail-multiple-images.yaml
+++ b/tasks/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref-fail-multiple-images.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-get-git-sha-image-ref-fail-multiple-images
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the get-git-sha-image-ref-from-release task with a Release having multiple artifact images.
+    The task only supports Releases with one artifact image, so the task should fail.
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-cr
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-sample
+                namespace: default
+                labels:
+                  pac.test.appstudio.openshift.io/sha: abcdefg12345
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+
+              # Status needs to be patched in, can't be added at apply time
+              kubectl --warnings-as-errors=true patch release -n default release-sample --type=merge \
+                --subresource status --patch \
+                "status: {'artifacts':{'images':[{'urls':['quay.io/konflux-ci/myimage:abcdefg12345',
+                'quay.io/konflux-ci/myimage:abcde']},{'urls':['foo']}]}}"
+    - name: run-task
+      taskRef:
+        name: get-git-sha-image-ref-from-release
+      params:
+        - name: release
+          value: default/release-sample
+      runAfter:
+        - setup
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-sample

--- a/tasks/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref-fail-no-label.yaml
+++ b/tasks/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref-fail-no-label.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-get-git-sha-image-ref-fail-no-label
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the get-git-sha-image-ref-from-release task and without the git sha PaC label on the Release.
+    The task should fail
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-cr
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-sample
+                namespace: default
+                labels:
+                  foo: bar
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+
+              # Status needs to be patched in, can't be added at apply time
+              kubectl --warnings-as-errors=true patch release -n default release-sample --type=merge \
+                --subresource status --patch \
+                "status: {'artifacts':{'images':[{'urls':['quay.io/konflux-ci/myimage:abcdefg12345',
+                'quay.io/konflux-ci/myimage:abcde']}]}}"
+    - name: run-task
+      taskRef:
+        name: get-git-sha-image-ref-from-release
+      params:
+        - name: release
+          value: default/release-sample
+      runAfter:
+        - setup
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-sample

--- a/tasks/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref-fail-no-matching-imageref.yaml
+++ b/tasks/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref-fail-no-matching-imageref.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-get-git-sha-image-ref-fail-no-matching-imageref
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the get-git-sha-image-ref-from-release task with no imageRef in the Release artifacts matching
+    the git sha from the PaC label. The task should fail
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-cr
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-sample
+                namespace: default
+                labels:
+                  pac.test.appstudio.openshift.io/sha: abcdefg12345
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+
+              # Status needs to be patched in, can't be added at apply time
+              kubectl --warnings-as-errors=true patch release -n default release-sample --type=merge \
+                --subresource status --patch \
+                "status: {'artifacts':{'images':[{'urls':['quay.io/konflux-ci/myimage:wrong',
+                'quay.io/konflux-ci/myimage:nope']}]}}"
+    - name: run-task
+      taskRef:
+        name: get-git-sha-image-ref-from-release
+      params:
+        - name: release
+          value: default/release-sample
+      runAfter:
+        - setup
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-sample

--- a/tasks/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref-fail-no-release.yaml
+++ b/tasks/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref-fail-no-release.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-get-git-sha-image-ref-fail-no-release
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the get-git-sha-image-ref-from-release with no Release CR present. The task should fail
+  tasks:
+    - name: run-task
+      taskRef:
+        name: get-git-sha-image-ref-from-release
+      params:
+        - name: release
+          value: default/release-sample

--- a/tasks/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref.yaml
+++ b/tasks/get-git-sha-image-ref-from-release/tests/test-get-git-sha-image-ref.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-get-git-sha-image-ref
+spec:
+  description: |
+    Run the get-git-sha-image-ref-from-release task and ensure the proper imageRef is found
+  tasks:
+    - name: setup
+      taskSpec:
+        steps:
+          - name: create-cr
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-sample
+                namespace: default
+                labels:
+                  pac.test.appstudio.openshift.io/sha: abcdefg12345
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+
+              # Status needs to be patched in, can't be added at apply time
+              kubectl --warnings-as-errors=true patch release -n default release-sample --type=merge \
+                --subresource status --patch \
+                "status: {'artifacts':{'images':[{'urls':['quay.io/konflux-ci/myimage:abcdefg12345',
+                'quay.io/konflux-ci/myimage:abcde']}]}}"
+    - name: run-task
+      taskRef:
+        name: get-git-sha-image-ref-from-release
+      params:
+        - name: release
+          value: default/release-sample
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: imageRef
+          value: $(tasks.run-task.results.imageRef)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: imageRef
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo Test the imageRef result was properly set
+              test "$(params.imageRef)" == "quay.io/konflux-ci/myimage:abcdefg12345"
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-sample

--- a/tasks/update-manager-image-in-git/OWNERS
+++ b/tasks/update-manager-image-in-git/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+  - Paul123111
+  - johnbieren
+  - mmalina
+  - happybhati
+  - davidmogar
+  - theflockers
+  - seanconroy2021
+  - filipnikolovski

--- a/tasks/update-manager-image-in-git/README.md
+++ b/tasks/update-manager-image-in-git/README.md
@@ -1,0 +1,15 @@
+# update-manager-image-in-git
+
+Updates the image line in the manager yaml files in the internal-services/manager directory.
+If mode is `pr`, a pull request is created for the update. If mode is `push`, the change is pushed
+directly.
+
+## Parameters
+
+| Name         | Description                                                                                   | Optional | Default value                                          |
+|--------------|-----------------------------------------------------------------------------------------------|----------|--------------------------------------------------------|
+| mode         | Whether the task should create a pull request or directly push. Options are [pr, push]        | No       | -                                                      |
+| repoBranch   | The branch in the repo to target                                                              | Yes      | main                                                   |
+| repoUrl      | The repo to update, starting with github.com, without https:// (e.g. github.com/org/repo.git) | Yes      | github.com/hacbs/release/app-interface-deployments.git |
+| githubSecret | The secret containing a `token` key with value set to the GitHub access token                 | No       | -                                                      |
+| image        | The manager image to update to                                                                | No       | -                                                      |

--- a/tasks/update-manager-image-in-git/tests/mocks.sh
+++ b/tasks/update-manager-image-in-git/tests/mocks.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# mocks to be injected into task step scripts
+function git() {
+  echo "Mock git called with: $*"
+
+  if [[ "$*" == *"clone"* ]]; then
+    gitRepo=$(awk '{print $NF}' <<< $*)
+    mkdir -p "$gitRepo"/internal-services/manager
+    echo "image: quay.io/konflux-ci/internal-services:old" | tee \
+      "$gitRepo"/internal-services/manager/one.yaml \
+      "$gitRepo"/internal-services/manager/two.yaml \
+      "$gitRepo"/internal-services/manager/three.yaml
+  else
+    # Mock the other git functions to pass
+    : # no-op - do nothing
+  fi
+}
+
+function gh() {
+  echo "Mock gh called with: $*"
+}

--- a/tasks/update-manager-image-in-git/tests/pre-apply-task-hook.sh
+++ b/tasks/update-manager-image-in-git/tests/pre-apply-task-hook.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+kubectl delete secret update-manager-secret --ignore-not-found
+kubectl create secret generic update-manager-secret --from-literal=token=abcdefghijk --from-literal=name=release-team --from-literal=email=release@domain.com

--- a/tasks/update-manager-image-in-git/tests/test-update-manager-fail-invalid-mode.yaml
+++ b/tasks/update-manager-image-in-git/tests/test-update-manager-fail-invalid-mode.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-manager-fail-invalid-mode
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the update-manager-image-in-git with an invalid `mode` param and ensure the task fails.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: update-manager-image-in-git
+      params:
+        - name: mode
+          value: other
+        - name: repoBranch
+          value: fail-branch
+        - name: repoUrl
+          value: github.com/org/repo
+        - name: githubSecret
+          value: update-manager-secret
+        - name: image
+          value: quay.io/konflux-ci/internal-services:12345678

--- a/tasks/update-manager-image-in-git/tests/test-update-manager.yaml
+++ b/tasks/update-manager-image-in-git/tests/test-update-manager.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-manager
+spec:
+  description: |
+    Run the update-manager-image-in-git task. It doesn't use a workspace, so there isn't a way to
+    ensure the changes were made, but we can still check that the task succeeds.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: update-manager-image-in-git
+      params:
+        - name: mode
+          value: pr
+        - name: repoBranch
+          value: main
+        - name: repoUrl
+          value: github.com/org/repo
+        - name: githubSecret
+          value: update-manager-secret
+        - name: image
+          value: quay.io/konflux-ci/internal-services:12345678

--- a/tasks/update-manager-image-in-git/update-manager-image-in-git.yaml
+++ b/tasks/update-manager-image-in-git/update-manager-image-in-git.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: update-manager-image-in-git
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "release, tenant"
+spec:
+  description: |
+      Updates the image line in the manager yaml files in the internal-services/manager directory.
+      If mode is `pr`, a pull request is created for the update. If mode is `push`, the change is pushed
+      directly.
+  params:
+    - name: mode
+      type: string
+      description: Whether the task should create a pull request or directly push. Options are [pr, push]
+    - name: repoBranch
+      type: string
+      description: The branch in the repo to target
+      default: main
+    - name: repoUrl
+      type: string
+      description: The repo to update, starting with github.com, without https:// (e.g. github.com/org/repo.git)
+      default: github.com/hacbs/release/app-interface-deployments.git
+    - name: githubSecret
+      type: string
+      description: The secret containing a `token` key with value set to the GitHub access token
+    - name: image
+      type: string
+      description: The manager image to update to
+  steps:
+    - name: update-repo
+      image: quay.io/konflux-ci/release-service-utils:9089cafbf36bb889b4b73d8c2965613810f13736
+      env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.githubSecret)
+              key: token
+        - name: EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.githubSecret)
+              key: email
+        - name: NAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.githubSecret)
+              key: name
+      script: |
+          #!/usr/bin/env bash
+          set -euxo pipefail
+
+          if ! [[ "$(params.mode)" =~ ^(push|pr)$ ]] ; then
+              echo "Invalid mode parameter. Only 'pr' and 'push' are allowed."
+              exit 1
+          fi
+
+          # Switch to /tmp to avoid filesystem permission issues
+          cd /tmp
+
+          set +x
+          git clone "https://oauth2:$GITHUB_TOKEN@$(params.repoUrl)" gitRepo
+          set -x
+          cd gitRepo
+          git config --global user.name "$NAME"
+          git config --global user.email "$EMAIL"
+          git checkout "$(params.repoBranch)"
+
+          BRANCH=$(params.repoBranch)
+          if [ "$(params.mode)" = "pr" ] ; then
+              BRANCH="automated-manager-update"
+              git checkout -b "$BRANCH"
+          fi
+
+          # Perform substitution
+          find internal-services/manager -type f -name "*.yaml" -exec \
+            sed -i "s|quay.io/konflux-ci/internal-services:.*|$(params.image)|" {} \;
+
+          git add .
+          TITLE="chore: update manager image in $(params.repoBranch)"
+          git commit -m "$TITLE"
+          git push -f origin "$BRANCH"
+
+          if [ "$(params.mode)" = "pr" ] ; then
+              # This command will fail if there is already an open PR. In this case, the push before this
+              # will update the PR so it is okay if this fails
+              gh pr create --base "$(params.repoBranch)" --head "$BRANCH" --title "$TITLE" --body "" || true
+          fi


### PR DESCRIPTION
Move the final pipeline resources that update the internal-services manager from the release-service-catalog to this repo. They will then be removed from release-service-catalog.