### PR TITLE
feat(RELEASE-1725): auto generate README.md files for tasks/pipelines

### DIFF
--- a/.github/scripts/check_readme.sh
+++ b/.github/scripts/check_readme.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# This script will verify that the README.md of all task and 
+# pipeline directories provided matches the output of hack/readme_generator.sh
+# to ensure that README files are up to date.
+#
+# Task and pipeline directories are provided
+# either via README_ITEMS env var, or as arguments
+# when running the script.
+
+CLI_README_ITEMS=()
+FAILED_ITEMS=()
+FAILED_PARAMS=()
+
+show_help() {
+  echo "Usage: $0 [item1] [item2] [...]"
+  echo
+  echo Flags:
+  echo "  --help: Show this help message"
+  echo
+  echo "Items are task or pipeline directories. They can be supplied"
+  echo "either as arguments or via the README_ITEMS environment variable."
+  echo
+  echo "Examples:"
+  echo "  $0 tasks/push-snapshot-to-quay pipelines/push-snapshot-to-quay tasks/task-name"
+  echo
+  echo "  or"
+  echo
+  echo '  export README_ITEMS="tasks/push-snapshot-to-quay pipelines/push-snapshot-to-quay tasks/task-name"'
+  echo "  $0"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)
+      show_help
+      ;;
+    --*)
+      show_help
+      ;;
+    *)
+      CLI_README_ITEMS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "${#CLI_README_ITEMS[@]}" -gt 0 ]]; then
+  README_ITEMS=("${CLI_README_ITEMS[@]}")
+else
+  read -r -a README_ITEMS <<< "${README_ITEMS[@]}"
+fi
+
+if [ "${#README_ITEMS[@]}" -eq 0 ]
+then
+  show_help
+fi
+
+# Check that all directories exist. If not, fail
+for ITEM in "${README_ITEMS[@]}"
+do
+  if [[ -d "$ITEM" ]]; then
+    true
+  else
+    echo "Error: Invalid file or directory: $ITEM"
+    exit 1
+  fi
+done
+
+for ITEM in "${README_ITEMS[@]}"
+do
+  echo "Task/Pipeline item: $ITEM"
+  ITEM_NAME=$(basename "$ITEM")
+  ITEM_DIR=$(cut -d '/' -f -2 <<< "$ITEM")
+  echo "  Task/Pipeline name: $ITEM_NAME"
+
+  ITEM_PATH=${ITEM_DIR}/${ITEM_NAME}.yaml
+  if [ ! -f "$ITEM_PATH" ]; then
+    echo "  Error: Task/Pipeline file does not exist: $ITEM_PATH"
+    exit 1
+  fi
+
+  if [[ $(yq ".spec | has(\"description\")" "$ITEM_PATH") == "false" ]]; then
+    echo "  Error in $ITEM: Field '.spec.description' is missing in task"
+    FAILED_ITEMS+=("$ITEM - no description")
+  fi
+
+  # Check description doesn't have '.' or ','
+  PARAMS=$(yq .spec.params "$ITEM_PATH")
+  for ((i=0; i < $(yq length <<< "$PARAMS"); i++)); do
+    # Get rid of newlines and remove trailing whitespace
+    DESCRIPTION="$(yq .[$i].description <<< "$PARAMS" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+    NAME="$(yq .[$i].name <<< "$PARAMS" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+
+    if [[ $(yq ".[$i] | has(\"description\")" <<< "$PARAMS") == "false" ]]; then
+      echo "  Error in $ITEM: Field '.param.[$i].description' ($NAME) is missing in task"
+      FAILED_PARAMS+=("$ITEM_PATH: $NAME - missing description")
+    elif [[ "${DESCRIPTION: -1}" =~ [.,] ]]; then
+      echo "  Error in $NAME: Description should not end with a '${DESCRIPTION: -1}'"
+      FAILED_PARAMS+=("$ITEM_PATH: $NAME - invalid description")
+    fi
+  done
+
+  README_PATH=${ITEM_DIR}/README.md
+  if [ ! -f "$README_PATH" ]
+  then
+    echo "  Error: README does not exist in $ITEM_DIR"
+    FAILED_ITEMS+=("$ITEM - no README.md")
+    continue
+  fi
+
+  if ! diff -u <(.github/scripts/readme_generator.sh --dry-run --no-debug "$ITEM_DIR") "$README_PATH"; then
+    echo "  Error: README.md has not been updated. Please use hack/readme-generator.sh to" \
+      "generate a new README.md to replace $ITEM/README.md"
+    FAILED_ITEMS+=("$ITEM - outdated README.md")
+  else
+    echo "  README.md for $ITEM_DIR is up to date"
+  fi
+
+done
+
+if [[ "${#FAILED_PARAMS[@]}" -eq 0 ]]; then
+  echo
+  echo "All task/pipeline parameter descriptions are valid."
+else
+  echo
+  echo "Error: these task/pipeline parameter descriptions must be updated:"
+  for PARAM in "${FAILED_PARAMS[@]}"; do
+    echo "  $PARAM"
+  done
+
+  if [[ "${#FAILED_ITEMS[@]}" -eq 0 ]]; then
+    exit 1
+  fi
+fi
+
+if [[ "${#FAILED_ITEMS[@]}" -eq 0 ]]; then
+  echo
+  echo "All README.md files are up to date"
+else
+  echo
+  echo "Error: these task/pipeline README.md files must be updated:"
+  for ITEM in "${FAILED_ITEMS[@]}"; do
+    echo "  $ITEM"
+  done
+  echo
+  if [[ "${#FAILED_PARAMS[@]}" -eq 0 ]]; then
+    echo "Add missing descriptions to tasks/pipelines (if there are any)," \
+      "then try running the following command to fix this:"
+  else
+    echo "Fix any invalid or missing parameter descriptions and add missing descriptions" \
+      "to tasks/pipelines (if there are any), then try running the" \
+      "following command to fix this:"
+  fi
+  # Get unique items in array
+  FAILED_ITEMS=($(printf "%s\n" "${FAILED_ITEMS[@]% - *}" | sort -u ))
+  echo "./.github/scripts/readme_generator.sh" "${FAILED_ITEMS[@]}"
+  exit 1
+fi

--- a/.github/scripts/readme_generator.sh
+++ b/.github/scripts/readme_generator.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+
+# Automatically generates a README.md for tasks and pipelines.
+# Without the '--dry-run' flag, this will automatically replace the current task/pipeline README.md
+#
+# This script takes the '.spec.description' and '.spec.params' fields 
+# from the associated task/pipeline to create the description and table in the README.md of this task/pipeline.
+#
+# If you wish to update the README.md description and table, please update the '.spec.description' or '.spec.table'
+# field in the Tekton task/pipeline and run this script, instead of changing it manually in the README.md.
+#
+# Usage: ./readme_generator.sh tasks/apply-mapping
+
+show_help() {
+  echo "Usage: $0 [--dry-run] [item1] [item2] [...]"
+  echo
+  echo Flags:
+  echo "  --help: Show this help message"
+  echo "  --dry-run: Print the updated README.md files without changing"
+  echo "             the current README.md in each task and pipeline"
+  echo "  --no-debug: Don't print debug messages (except errors)"
+  echo
+  echo "Items are task or pipeline directories. They can be supplied"
+  echo "either as arguments or via the README_ITEMS environment variable."
+  echo
+  echo "Examples:"
+  echo "  $0 tasks/push-snapshot-to-quay"
+  echo "  $0 --dry-run tasks/push-snapshot-to-quay"
+    echo "  $0 --dry-run --no-debug tasks/push-snapshot-to-quay"
+  echo
+  echo "  or"
+  echo
+  echo '  export README_ITEMS="tasks/push-snapshot-to-quay pipelines/push-snapshot-to-quay tasks/task-name"'
+  echo "  $0"
+  exit 1
+}
+
+DRY_RUN=false
+NO_DEBUG=false
+CLI_README_ITEMS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --no-debug)
+      NO_DEBUG=true
+      shift
+      ;;
+    --help)
+      show_help
+      ;;
+    --*)
+      show_help
+      ;;
+    *)
+      CLI_README_ITEMS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "${#CLI_README_ITEMS[@]}" -gt 0 ]]; then
+  README_ITEMS=("${CLI_README_ITEMS[@]}")
+else
+  read -r -a README_ITEMS <<< "${README_ITEMS[@]}"
+fi
+
+if [ "${#README_ITEMS[@]}" -eq 0 ]
+then
+  show_help
+fi
+
+# Check that all directories exist. If not, fail
+for ITEM in "${README_ITEMS[@]}"
+do
+  if [[ ! -d "$ITEM" ]]; then
+    echo "Error: Invalid file or directory: $ITEM"
+    exit 1
+  fi
+
+  ITEM_NAME=$(basename "$ITEM")
+  ITEM_DIR=$(cut -d '/' -f -2 <<< "$ITEM")
+
+  ITEM_PATH=${ITEM_DIR}/${ITEM_NAME}.yaml
+  if [ ! -f "$ITEM_PATH" ]
+  then
+    echo "Error: Task/Pipeline file does not exist: $ITEM_PATH"
+    exit 1
+  fi
+done
+
+# Creating after checking all directories exist to simplify cleanup
+TEMP_README=$(mktemp)
+
+# Add table
+for ITEM in "${README_ITEMS[@]}"
+do
+  ITEM_DIR=$(cut -d '/' -f -2 <<< "$ITEM")
+  BASE_DIR=$(cut -d '/' -f 1 <<< "$ITEM")
+  ITEM_NAME=$(basename "$ITEM")
+  ITEM_PATH=${ITEM_DIR}/${ITEM_NAME}.yaml
+
+  # Don't print any debug messages when no debug is true
+  $NO_DEBUG || echo "Task/Pipeline item: $ITEM"
+  $NO_DEBUG || echo "  Task/Pipeline name: $ITEM_NAME"
+
+  # Variables for description of README.md
+  METADATA_NAME=$(yq .metadata.name "$ITEM_PATH")
+  SPEC_DESCRIPTION=$(yq .spec.description "$ITEM_PATH")
+
+  # Variables for table
+  PARAMS=$(yq .spec.params "$ITEM_PATH")
+
+  # Get the maximum length for each column of table
+  LONGEST_NAME=0
+  LONGEST_DESCRIPTION=0
+  LONGEST_DEFAULT=13
+  LONGEST_OPTIONAL=8
+
+  for ((i=0; i < $(yq length <<< "$PARAMS"); i++)); do
+    # Get rid of newlines and remove trailing whitespace
+    NAME="$(yq .[$i].name <<< "$PARAMS" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+    DESCRIPTION="$(yq .[$i].description <<< "$PARAMS" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+    DEFAULT="$(yq .[$i].default <<< "$PARAMS" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+
+    if [[ ${#NAME} -gt $LONGEST_NAME ]]; then
+      LONGEST_NAME=${#NAME}
+    fi
+    
+    if [[ ${#DESCRIPTION} -gt $LONGEST_DESCRIPTION ]]; then
+      LONGEST_DESCRIPTION=${#DESCRIPTION}
+    fi
+
+    if [[ ${#DEFAULT} -gt $LONGEST_DEFAULT ]]; then
+      LONGEST_DEFAULT=${#DEFAULT}
+    fi
+  done
+
+  # create table and write contents to file
+  {
+    if [[ "$BASE_DIR" == "pipelines" && "$ITEM_NAME" != *-pipeline ]]; then
+      echo "# $METADATA_NAME pipeline"
+    elif [[ "$BASE_DIR" == "pipelines" && "$ITEM_NAME" == *-pipeline ]]; then
+      echo "# ${METADATA_NAME%-pipeline} pipeline"
+    else
+      echo "# $METADATA_NAME"
+    fi
+    echo
+    echo "$SPEC_DESCRIPTION"
+    echo
+    echo "## Parameters"
+    echo
+
+    # Print first row of table
+    printf '| Name %*s' "$(($LONGEST_NAME-4))"
+    printf '| Description %*s' "$(($LONGEST_DESCRIPTION-11))"
+    printf '| Optional %*s' "$(($LONGEST_OPTIONAL-8))"
+    printf '| Default value %*s|\n' "$(($LONGEST_DEFAULT-13))"
+
+    # Print second row of table
+    printf '|-%*s-' "$(($LONGEST_NAME))" | tr ' ' '-'
+    printf '|-%*s-' "$(($LONGEST_DESCRIPTION))" | tr ' ' '-'
+    printf '|-%*s-' "$(($LONGEST_OPTIONAL))" | tr ' ' '-'
+    printf '|-%*s-|\n' "$(($LONGEST_DEFAULT))" | tr ' ' '-'
+
+    # Print remaining rows of table
+    for ((i=0; i < $(yq length <<< "$PARAMS"); i++)); do
+      # Get rid of newlines and remove trailing whitespace
+      NAME="$(yq .[$i].name <<< "$PARAMS" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+      DESCRIPTION="$(yq .[$i].description <<< "$PARAMS" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+      DEFAULT="$(yq .[$i].default <<< "$PARAMS" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+
+      printf "| $NAME %*s" "$(($LONGEST_NAME-${#NAME}))"
+      printf "| $DESCRIPTION %*s" "$(($LONGEST_DESCRIPTION-${#DESCRIPTION}))"
+
+      # Check that default doesn't exist
+      if [[ $(yq ".[$i] | has(\"default\")" <<< "$PARAMS") == "false" ]]; then
+        printf "| No %*s" "$(($LONGEST_OPTIONAL-2))"
+        printf "| - %*s|\n" "$(($LONGEST_DEFAULT-1))"
+      else
+        # Special case to show default empty strings as "" in table
+        if [[ -z "$DEFAULT" ]]; then
+          DEFAULT="\"\""
+        fi
+        printf "| Yes %*s" "$(($LONGEST_OPTIONAL-3))"
+        printf "| $DEFAULT %*s|\n" "$(($LONGEST_DEFAULT-${#DEFAULT}))"
+      fi
+    done
+  } > "$TEMP_README"
+
+  if [[ $DRY_RUN == "true" ]]; then
+    cat "$TEMP_README"
+  else
+    cat "$TEMP_README" > "${ITEM_DIR}/README.md"
+  fi
+  $NO_DEBUG || $DRY_RUN || echo "  README.md for $ITEM_DIR updated"
+done
+
+# Cleanup
+if [ -v TEMP_README ]; then
+  rm -f "$TEMP_README"
+fi

--- a/pipelines/notify-slack-on-failure/README.md
+++ b/pipelines/notify-slack-on-failure/README.md
@@ -1,10 +1,10 @@
 # notify-slack-on-failure pipeline
 
-Sends an error message to Slack using postMessage API if managed pipelines fail.
+Sends an error message to Slack using postMessage API if managed pipelines fail
 
 ## Parameters
 
-| Name            | Description                                                                     | Optional | Default Value                                       |
+| Name            | Description                                                                     | Optional | Default value                                       |
 |-----------------|---------------------------------------------------------------------------------|----------|-----------------------------------------------------|
 | secretName      | Name of secret which contains authentication token for app                      | No       | -                                                   |
 | secretKeyName   | Name of key within secret which contains webhook URL                            | No       | -                                                   |

--- a/pipelines/notify-slack-on-failure/notify-slack-on-failure.yaml
+++ b/pipelines/notify-slack-on-failure/notify-slack-on-failure.yaml
@@ -7,7 +7,8 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
 spec:
-  description: Sends an error message to Slack using postMessage API if managed pipelines fail
+  description: |-
+    Sends an error message to Slack using postMessage API if managed pipelines fail
   params:
     - name: secretName
       type: string

--- a/pipelines/push-snapshot-to-quay/README.md
+++ b/pipelines/push-snapshot-to-quay/README.md
@@ -9,11 +9,11 @@ contains a status indicating that a managed pipeline has successfully completed.
 
 ## Parameters
 
-| Name            | Description                                                                     | Optional | Default Value                                       |
-|-----------------|---------------------------------------------------------------------------------|----------|-----------------------------------------------------|
-| releasePlan     | Namespaced name of release plan - should be in format "namespace/name"          | No       | -                                                   |
-| snapshot        | Namespaced name of snapshot - should be in format "namespace/name"              | No       | -                                                   |
-| release         | Namespaced name of release - should be in format "namespace/name"               | No       | -                                                   |
-| requireSuccessfulManagedRelease | Only push if the managed release status is successful ("true"/"false") | Yes      | "false"        |
-| taskGitUrl      | The url to the git repo where the community-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/community-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used                                  | No       | -                                                   |
+| Name                            | Description                                                                     | Optional | Default value                                       |
+|---------------------------------|---------------------------------------------------------------------------------|----------|-----------------------------------------------------|
+| releasePlan                     | Namespaced name of release plan - should be in format "namespace/name"          | No       | -                                                   |
+| snapshot                        | Namespaced name of snapshot - should be in format "namespace/name"              | No       | -                                                   |
+| taskGitUrl                      | The url to the git repo where the community-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/community-catalog.git |
+| taskGitRevision                 | The revision in the taskGitUrl repo to be used                                  | No       | -                                                   |
+| release                         | Namespaced name of release - should be in format "namespace/name"               | No       | -                                                   |
+| requireSuccessfulManagedRelease | Only push if the managed release status is successful                           | Yes      | false                                               |

--- a/pipelines/push-snapshot-to-quay/push-snapshot-to-quay.yaml
+++ b/pipelines/push-snapshot-to-quay/push-snapshot-to-quay.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
 spec:
-  description: >-
+  description: |-
     Tekton task to push snapshot images to quay.io using `cosign copy`. The destination for
     each image is taken from the '.spec.data.mapping' section of the release plan, in the form
     '.spec.data.mapping.components.repository', and '.spec.data.mapping.components.tags'.

--- a/pipelines/update-internal-services-manager/README.md
+++ b/pipelines/update-internal-services-manager/README.md
@@ -1,4 +1,4 @@
-# update-internal-services-manager
+# update-internal-services-manager pipeline
 
 Tekton pipeline to update the internal-services manager yaml to the latest image in the
 hacbs-release/app-interface-deployments repository.

--- a/pipelines/update-internal-services-manager/update-internal-services-manager.yaml
+++ b/pipelines/update-internal-services-manager/update-internal-services-manager.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "release, tenant"
 spec:
-  description: >-
+  description: |-
     Tekton pipeline to update the internal-services manager yaml to the latest image in the
     hacbs-release/app-interface-deployments repository.
   params:

--- a/tasks/get-git-sha-image-ref-from-release/README.md
+++ b/tasks/get-git-sha-image-ref-from-release/README.md
@@ -13,6 +13,6 @@ done via the `imageRef` task result.
 
 ## Parameters
 
-| Name    | Description                    | Optional | Default value |
-|---------|--------------------------------|----------|---------------|
-| release | Namespaced name of the Release | No       | -             |
+| Name    | Description                        | Optional | Default value |
+|---------|------------------------------------|----------|---------------|
+| release | The namespaced name of the Release | No       | -             |

--- a/tasks/get-git-sha-image-ref-from-release/get-git-sha-image-ref-from-release.yaml
+++ b/tasks/get-git-sha-image-ref-from-release/get-git-sha-image-ref-from-release.yaml
@@ -7,8 +7,17 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "release, tenant"
 spec:
-  description: >-
-    Tekton task to output the imageRef stored in the Release artifacts that corresponds to the git sha tag.
+  description: |-
+    Tekton task to get the image reference containing the git sha tag from the Release artifacts.
+
+    It finds the git sha by checking for the `pac.test.appstudio.openshift.io/sha` label on the Release CR.
+    If it is not found, the task will fail with error.
+
+    This task is only meant to work with Releases for one component. If the task finds there are more than one image
+    in its artifacts, it will fail with error.
+
+    Once it has the git sha, the task simply returns the image url from the artifacts that ends with it. This is
+    done via the `imageRef` task result.
   params:
     - name: release
       type: string

--- a/tasks/notify-slack-on-failure/README.md
+++ b/tasks/notify-slack-on-failure/README.md
@@ -1,10 +1,10 @@
 # notify-slack-on-failure
 
-Tekton task that sends an error message to Slack using postMessage API if managed pipelines fail.
+Sends an error message to Slack using postMessage API if managed pipelines fail
 
 ## Parameters
 
-| Name          | Description                                                       | Optional | Default Value |
+| Name          | Description                                                       | Optional | Default value |
 |---------------|-------------------------------------------------------------------|----------|---------------|
 | secretName    | Name of secret which contains authentication token for app        | No       | -             |
 | secretKeyName | Name of key within secret which contains webhook URL              | No       | -             |

--- a/tasks/notify-slack-on-failure/notify-slack-on-failure.yaml
+++ b/tasks/notify-slack-on-failure/notify-slack-on-failure.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: notify-slack-on-failure
 spec:
-  description: >-
+  description: |-
     Sends an error message to Slack using postMessage API if managed pipelines fail
   params:
     - name: secretName

--- a/tasks/push-snapshot-to-quay/README.md
+++ b/tasks/push-snapshot-to-quay/README.md
@@ -1,6 +1,6 @@
 # push-snapshot-to-quay
 
-Tekton task to push snapshot images to quay.io using `cosign copy`. The destination for 
+Tekton task to push snapshot images to quay.io using `cosign copy`. The destination for
 each image is taken from the '.spec.data.mapping' section of the release plan, in the form
 '.spec.data.mapping.components.repository', and '.spec.data.mapping.components.tags'.
 
@@ -9,9 +9,9 @@ contains a status indicating that a managed pipeline has successfully completed.
 
 ## Parameters
 
-| Name        | Description                                                            | Optional | Default Value |
-|-------------|------------------------------------------------------------------------|----------|---------------|
-| release     | Namespaced name of release - should be in format "namespace/name"      | No       | -             |
-| releasePlan | Namespaced name of release plan - should be in format "namespace/name" | No       | -             |
-| requireSuccessfulManagedRelease | Only push if the managed release status is successful ("true"/"false") | Yes      | "false"        |
-| snapshot    | Namespaced name of snapshot - should be in format "namespace/name"     | No       | -             |
+| Name                            | Description                                                            | Optional | Default value |
+|---------------------------------|------------------------------------------------------------------------|----------|---------------|
+| release                         | Namespaced name of release - should be in format "namespace/name"      | No       | -             |
+| releasePlan                     | Namespaced name of release plan - should be in format "namespace/name" | No       | -             |
+| requireSuccessfulManagedRelease | Only push if the managed release status is successful                  | No       | -             |
+| snapshot                        | Namespaced name of snapshot - should be in format "namespace/name"     | No       | -             |

--- a/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
+++ b/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot-to-quay
 spec:
-  description: >-
+  description: |-
     Tekton task to push snapshot images to quay.io using `cosign copy`. The destination for
     each image is taken from the '.spec.data.mapping' section of the release plan, in the form
     '.spec.data.mapping.components.repository', and '.spec.data.mapping.components.tags'.

--- a/tasks/update-manager-image-in-git/update-manager-image-in-git.yaml
+++ b/tasks/update-manager-image-in-git/update-manager-image-in-git.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "release, tenant"
 spec:
-  description: |
+  description: |-
       Updates the image line in the manager yaml files in the internal-services/manager directory.
       If mode is `pr`, a pull request is created for the update. If mode is `push`, the change is pushed
       directly.


### PR DESCRIPTION
Add readme_generator.sh, which generates README.md files for tasks and pipelines, as well as a check_readme.sh script and workflow to check that the README.md files in each task and pipeline match the output of readme-generator.sh.

Also updated all README.md files using this script.