### PR TITLE
Create `trigger-nudge` pipeline

### DIFF
--- a/pipelines/trigger-nudge-for-component/OWNERS
+++ b/pipelines/trigger-nudge-for-component/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - abraham2512
+  - fontivan
+  - rauhersu
+  - sabbir-47
+  - shajmakh
+  - yanirq

--- a/pipelines/trigger-nudge-for-component/README.md
+++ b/pipelines/trigger-nudge-for-component/README.md
@@ -1,0 +1,21 @@
+# trigger-nudge-for-component Pipeline
+
+This pipeline orchestrates a direct component nudge. It gets the new image details from the release snapshot and then runs the Renovate task to create a PR.
+
+## Parameters
+
+| Name | Description | Optional | Default Value |
+| --- | --- | --- | --- |
+| `snapshot-name` | The name of the `Snapshot` from the completed release. | No | - |
+| `component-to-nudge` | The name of the component in the snapshot whose new image should be used for the update. | No | - |
+| `git-repo-to-update` | The full Git URL of the repository that should receive the update pull request. | No | - |
+| `git-token-secret-name` | The name of the Kubernetes secret (in the release namespace) containing the Git hosting service token. | No | - |
+| `file-to-match` | A regex string for Renovate to find the file(s) to update (e.g., `Dockerfile`). | No | - |
+| `image-line-match-string` | A regex string for Renovate to find the exact image declaration line to replace. | No | - |
+| `namespace` | The application's namespace where the `Snapshot` resource exists. | No | - |
+
+## Workspaces
+
+| Name | Description |
+| --- | --- |
+| `trigger-nudge-for-component` | A workspace required by the pipeline which is used by the `run-renovate-for-component` task for cloning the repository and storing logs. This should be provided by the calling Release Plan. |

--- a/pipelines/trigger-nudge-for-component/trigger-nudge-for-component.yaml
+++ b/pipelines/trigger-nudge-for-component/trigger-nudge-for-component.yaml
@@ -1,0 +1,50 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: trigger-nudge-for-component
+spec:
+  description: >-
+    This pipeline orchestrates a direct component nudge. It gets the new
+    image details from the release snapshot and then runs the Renovate
+    task to create a PR.
+  params:
+    - name: snapshot-name
+    - name: component-to-nudge
+    - name: git-repo-to-update
+    - name: git-token-secret-name
+    - name: file-to-match
+    - name: image-line-match-string
+    - name: namespace
+  workspaces:
+    - name: trigger-nudge-for-component
+  tasks:
+    - name: get-image-details-from-snapshot
+      taskRef:
+        name: get-image-details-from-snapshot
+      params:
+        - name: snapshot-name
+          value: $(params.snapshot-name)
+        - name: component-name
+          value: $(params.component-to-nudge)
+        - name: namespace
+          value: $(params.namespace)
+    - name: run-renovate-for-component
+      runAfter: [get-image-details-from-snapshot]
+      taskRef:
+        name: run-renovate-for-component
+      workspaces:
+        - name: shared-workspace
+          workspace: trigger-nudge-for-component
+      params:
+        - name: git-repository-url
+          value: $(params.git-repo-to-update)
+        - name: git-token-secret-name
+          value: $(params.git-token-secret-name)
+        - name: image-name
+          value: $(tasks.get-image-details-from-snapshot.results.image-url)
+        - name: new-digest
+          value: $(tasks.get-image-details-from-snapshot.results.image-digest)
+        - name: file-match
+          value: $(params.file-to-match)
+        - name: match-strings
+          value: $(params.image-line-match-string)

--- a/tasks/get-image-details-from-snapshot/OWNERS
+++ b/tasks/get-image-details-from-snapshot/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - abraham2512
+  - fontivan
+  - rauhersu
+  - sabbir-47
+  - shajmakh
+  - yanirq

--- a/tasks/get-image-details-from-snapshot/README.md
+++ b/tasks/get-image-details-from-snapshot/README.md
@@ -1,0 +1,18 @@
+# get-image-details-from-snapshot Task
+
+This task retrieves a component's full container image string from a `Snapshot` resource. It then splits the string into the base image URL and the image digest, outputting them as results for use in subsequent tasks.
+
+## Parameters
+
+| Name | Description | Optional | Default Value |
+| --- | --- | --- | --- |
+| `snapshot-name` | The name of the `Snapshot` resource to query. | No | - |
+| `component-name` | The name of the component within the `Snapshot` to find the image for. | No | - |
+| `namespace` | The namespace where the `Snapshot` resource exists. | No | - |
+
+## Results
+
+| Name | Description |
+| --- | --- |
+| `image-url` | The URL of the container image (e.g., `quay.io/my-org/my-app`). |
+| `image-digest` | The digest of the container image (e.g., `sha256:abcdef...`). |

--- a/tasks/get-image-details-from-snapshot/get-image-details-from-snapshot.yaml
+++ b/tasks/get-image-details-from-snapshot/get-image-details-from-snapshot.yaml
@@ -1,0 +1,35 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: get-image-details-from-snapshot
+spec:
+  description: >-
+    This task retrieves a component's full container image string from a
+    Snapshot and splits it into the image URL and digest for downstream tasks.
+  params:
+    - name: snapshot-name
+      description: The name of the Snapshot resource.
+    - name: component-name
+      description: The name of the component within the Snapshot.
+    - name: namespace
+      description: The namespace where the Snapshot exists.
+  results:
+    - name: image-url
+      description: The URL of the container image without the tag or digest.
+    - name: image-digest
+      description: The digest of the container image.
+  steps:
+    - name: get-and-parse-imagedetails
+      image: registry.redhat.io/openshift4/ose-cli:latest
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+        FULL_IMAGE=$(oc get snapshot -n "$(params.namespace)" "$(params.snapshot-name)" -o jsonpath="{.spec.components[?(@.name=='$(params.component-name)')].containerImage}")
+        if [ -z "${FULL_IMAGE}" ]; then
+          echo "Error: Component '$(params.component-name)' not found in Snapshot '$(params.snapshot-name)'" >&2
+          exit 1
+        fi
+        IMAGE_URL=$(echo "${FULL_IMAGE}" | cut -d'@' -f1)
+        IMAGE_DIGEST=$(echo "${FULL_IMAGE}" | cut -d'@' -f2)
+        echo -n "${IMAGE_URL}" | tr -d '\n' > "$(results.image-url.path)"
+        echo -n "${IMAGE_DIGEST}" | tr -d '\n' > "$(results.image-digest.path)"

--- a/tasks/run-renovate-for-component/OWNERS
+++ b/tasks/run-renovate-for-component/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - abraham2512
+  - fontivan
+  - rauhersu
+  - sabbir-47
+  - shajmakh
+  - yanirq

--- a/tasks/run-renovate-for-component/README.md
+++ b/tasks/run-renovate-for-component/README.md
@@ -1,0 +1,21 @@
+# run-renovate-for-component Task
+
+This Task runs Renovate directly to create a pull request that updates a component's image digest in a git repository.
+
+## Parameters
+
+| Name | Description | Optional | Default Value |
+| --- | --- | --- | --- |
+| `git-repository-url` | The full Git repository URL to update (e.g., `https://github.com/org/repo.git`). | No | - |
+| `git-token-secret-name` | The name of the Kubernetes secret containing the Git hosting service token. | No | - |
+| `git-token-secret-key` | The key within the `git-token-secret-name` that holds the token value. | Yes | `token` |
+| `image-name` | The name of the container image to update (e.g., `quay.io/my-org/my-app`). | No | - |
+| `new-digest` | The new image digest to update to (e.g., `sha256:abcdef...`). | No | - |
+| `file-match` | A regex string to match files that should be scanned by Renovate. | Yes | `(^|/)Dockerfile$` |
+| `match-strings` | A regex string with a capture group to find the exact image declaration line to be replaced. Example: `"FROM quay.io/my-org/my-app(@sha256:[a-f0-9]+|:[\\w.-]+)"` | No | - |
+
+## Workspaces
+
+| Name | Description |
+| --- | --- |
+| `shared-workspace` | A workspace for Renovate to clone the repository and store logs. This should be provided by the calling pipeline. |

--- a/tasks/run-renovate-for-component/run-renovate-for-component.yaml
+++ b/tasks/run-renovate-for-component/run-renovate-for-component.yaml
@@ -1,0 +1,99 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: run-renovate-for-component
+spec:
+  description: >-
+    This Task runs Renovate directly to create a pull request that updates
+    a component's image digest in a git repository.
+  params:
+    - name: git-repository-url
+      description: The full Git repository URL to update (e.g., https://github.com/org/repo.git).
+      type: string
+    - name: git-token-secret-name
+      description: The name of the Kubernetes secret containing the Git hosting service token.
+      type: string
+    - name: git-token-secret-key
+      description: The key within the git-token-secret-name that holds the token value.
+      type: string
+      default: token
+    - name: image-name
+      description: The name of the container image to update (e.g., quay.io/my-org/my-app).
+      type: string
+    - name: new-digest
+      description: The new image digest to update to (e.g., sha256:abcdef...).
+      type: string
+    - name: file-match
+      description: A regex string to match files that should be scanned by Renovate.
+      type: string
+      default: "(^|/)Dockerfile$"
+    - name: match-strings
+      description: >-
+        A regex string with a capture group to find the exact image declaration line to be replaced.
+        Example: "FROM quay.io/my-org/my-app(@sha256:[a-f0-9]+|:[\\w.-]+)"
+      type: string
+  workspaces:
+    - name: shared-workspace
+      description: A workspace for renovate to clone the repo and store logs.
+  steps:
+    - name: run-renovate
+      image: renovate/renovate:41-full
+      workingDir: $(workspaces.shared-workspace.path)
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        seccompProfile:
+          type: RuntimeDefault
+      env:
+        - name: RENOVATE_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.git-token-secret-name)
+              key: $(params.git-token-secret-key)
+        - name: LOG_LEVEL
+          value: "debug"
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+
+        REPO_PATH=$(echo "$(params.git-repository-url)" | sed -E 's/https?:\/\/[^\/]+\///' | sed 's/\.git$//')
+
+        # Create a dynamic renovate.json config file.
+        # This config instructs renovate to perform one specific update.
+        cat > renovate.json <<EOF
+        {
+          "platform": "github",
+          "onboarding": false,
+          "requireConfig": "ignored",
+          "repositories": ["\${REPO_PATH}"],
+          "regexManagers": [
+            {
+              "fileMatch": ["$(params.file-match)"],
+              "matchStrings": ["$(params.match-strings)"],
+              "depNameTemplate": "$(params.image-name)",
+              "datasourceTemplate": "docker"
+            }
+          ],
+          "packageRules": [
+            {
+              "matchDatasources": ["docker"],
+              "matchDepNames": ["$(params.image-name)"],
+              "versioning": "digest",
+              "newVersion": "$(params.new-digest)",
+              "recreateWhen": "always"
+            }
+          ],
+          "prHourlyLimit": 0,
+          "prConcurrentLimit": 0
+        }
+        EOF
+
+        echo "--- Generated renovate.json ---"
+        cat renovate.json
+        echo "------------------------------------"
+
+        # Execute renovate with the generated config.
+        renovate --token="\${RENOVATE_TOKEN}" --config-file=renovate.json


### PR DESCRIPTION
- This can be used in the `finalPipeline` section of a `ReleasePlan`
- When used in this way, it will trigger a build nudge after the successful release
- This is useful for nudging FBCs as we only want the update to be done if the release was successful