### PR TITLE
feat(RELEASE-1493): add user documentation to community-catalog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,209 @@
+# Contributing
+
+Contributions of all kinds are welcome. In particular pull requests are appreciated.
+You can contribute your own tasks and pipelines, or modify existing tasks and pipelines.
+
+## Code of Conduct
+
+Our [company values](https://www.redhat.com/en/about/brand/standards/culture)
+guide us in our day-to-day interactions and decision-making. Our open source projects are
+no exception and they will define the standards for how to engage with the project
+through a [code of conduct](CODE_OF_CONDUCT.md).
+
+Please, make sure you read both of them before contributing, so you can help us
+to maintain a healthy community.
+
+## Submitting changes
+
+Before contributing code or documentation to this project, make sure you read the following sections.
+
+## Sample Tasks and Pipelines
+
+There are some sample tasks and pipelines you can use as an example when creating your own tenant tasks and pipelines:
+
+- [notify-slack-on-failure](tasks/notify-slack-on-failure)
+
+- [push-snapshot-to-quay](tasks/push-snapshot-to-quay)
+
+## OWNERS files
+
+This repository uses Prow review and approval plugins together with code ownership as encoded in OWNERS files to automatically select reviewers and merge pull requests.
+
+OWNERS files are needed in every task/pipeline to enforce who the codeowners of tenant tasks and pipelines are. A check is run to ensure that each task and pipeline has an OWNERS file. 
+
+Whenever a pull request is made to an existing task/pipeline, the OWNERS files in the task/pipeline will be checked and select two people at random from that file to review the pull request. For any changes outside of modifying an existing task/pipeline, two people from `release-service-maintainers` in the root OWNERS file will be selected for review (for example, adding a new task/pipeline).
+
+For more information about the Prow process, check [the k8s docs](https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#the-code-review-process).
+
+Note: only `/approve` is needed to merge a PR. `/lgtm` is not needed.
+
+## Keeping Documentation Up to Date
+
+Everything mentioned in this section is optional. If you want to use `.github/scripts/readme_generator.sh` to
+automatically maintain your task/pipeline's README.md, you can follow the instructions in this section. Otherwise, you can
+ignore the `Check README.md files` check on pull requests - it's not a required check.
+
+Whenever a task or pipeline is changed, you can run the `.github/scripts/readme_generator.sh` script with the
+changed task/pipeline directories as arguments to update the README.md description and parameter table.
+
+You can run a check to see if the task/pipelines match the output of this script
+ with the `.github/scripts/check_readme.sh` script.
+
+This script also checks if descriptions are present in each task/pipeline (and their parameters) and that they don't end with
+a trailing `.` or `,`
+
+If you want to use `.github/scripts/readme_generator.sh` for your task/pipeline,
+you should change the descriptions in the `yaml` file associated with the task/pipeline, and then run `.github/scripts/readme_generator.sh`
+with the changed task/pipeline directories as arguments. This is because the task/pipeline `yaml` file is considered the source of truth for each 
+task/pipeline README.md file. If you manually change the README.md file without updating the yaml, `check_readme.sh` will fail and `readme_generator.sh`
+will overwrite your changes. You should never have to update the README.md file manually if you're using this script.
+
+For more information, check the `.github/scripts/readme_generator.sh` and `.github/scripts/check_readme.sh` scripts.
+
+## Commit message formatting and standards
+
+The project follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification and enforces it using [gitlint](https://jorisroovers.com/gitlint/). The rules for this project are specified in the [.gitlint](.gitlint) config file. There is also a second rule file for the commit description that can be found in the [.github/gitlint directory](.github/gitlint).
+
+The commit message should contain an overall explanation about the change and the motivation behind it. Please note that mentioning a Jira ticket ID or a GitHub issue, isn't a replacement for that.
+
+A well formatted commit would look something like this:
+
+```
+feat(issue-id): what this commit does
+
+Overall explanation of what this commit is achieving and the motivation behind it.
+
+Signed-off-by: Your Name <your-name@your-email.com>
+```
+
+## Pull Request Title Prefixes
+
+The title prefix should be one of (`chore`|`docs`|`feat`|`fix`|`refactor`|`revert`|`style`|`test`) followed by a colon (`:`) and lowercase title. Optionally, you can include a Jira key.
+
+Examples:
+
+- fix(KFLUXSPRT-794): pass content-gateway token
+- feat: add rpms-signature-scan task
+
+Title prefixes:
+
+- **chore**: Changes that do not modify functionality (e.g., tool updates, or maintenance tasks).
+- **docs**: Documentation updates or additions (e.g., README changes, inline comments).
+- **feat**: Introduction of a new feature or functionality.
+- **fix**: Bug fixes or corrections to existing functionality.
+- **refactor**: Code changes that improve structure or readability without altering functionality.
+- **revert**: Reverting a previous commit or pull request.
+- **style**: Code formatting or stylistic changes that do not affect functionality (e.g., whitespace, linting).
+- **test**: Adding or updating tests (e.g., unit tests, integration tests).
+
+## Pull Requests
+
+All changes must come from a pull request (PR) and cannot be directly committed. While anyone can engage in activity on a PR, pull requests are only approved by team members.
+
+Before a pull request can be merged:
+
+* The content of the PR has to be relevant to the PR itself
+* The contribution must follow the style guidelines of this project
+* Multiple commits should be used if the PR is complex and clarity can be improved, but they should still relate to a single topic
+* For code contributions, tests have to be added/modified to ensure the code works
+* There has to be at least one approval
+* The feature branch must be rebased so it contains the latest changes from the target branch
+* The CI has to pass successfully
+* Every comment has to be addressed and resolved
+
+## Tekton Task Testing
+
+When a pull request is opened, Tekton Task tests are run for all the task directories that are being modified.
+
+The Github workflow is defined in .github/workflows/tekton_task_tests.yaml
+
+Tests are required for all tenant tasks that are added. A check is run to ensure that all tasks have a `tests/` directory.
+
+## Checkton check
+
+This repository uses [checkton](https://github.com/chmeliik/checkton) to run [shellcheck](https://www.shellcheck.net) on the embedded shell in the Tekton resources.
+
+This check shows itself as the `Linters / checkton (pull_request)` check on the pull request.
+
+If it fails and you click details, the tool does a pretty good job of highlighting the failures and telling you how to fix them.
+
+We strive to have all of our tekton resources abide by shellcheck, so this check is mandatory for pull requests submitted to this repo.
+
+##### Mocking commands executed in task scripts
+
+Mocks are needed when we want to test tasks which call external services (e.g. `skopeo copy`,
+`cosign download`, or even a python script from our release-utils image such as `create_container_image` that would
+call Pyxis API). The way to do this is to create a file with mock shell functions (with the same names
+as the commands you want to mock) and inject this file to the beginning of each `script` field in
+the task step that needs mocking.
+
+For reference implementation, check [push-snapshot-to-quay/tests/](tasks/push-snapshot-to-quay/tests/). Here's a breakdown of how it's done:
+
+1. Create a `mocks.sh` file in the tests directory of your task, e.g.
+    `tasks/create-pyxis-image/tests/mocks.sh`. This file will contain the mock function
+    definitions. It also needs to contain a shebang at the top as it will get injected to the top
+    of the original script. For example:
+
+    ```sh
+    #!/usr/bin/env sh
+    set -eux
+
+    function cosign() {
+      echo Mock cosign called with: $*
+      echo $* >> $(workspaces.data.path)/mock_cosign.txt
+
+      if [[ "$*" != "download sbom --output-file myImageID"[12]".json imageurl"[12] ]]
+      then
+        echo Error: Unexpected call
+        exit 1
+      fi
+
+      touch /workdir/sboms/${4}
+    }
+    ```
+
+    In the example above, you can notice two things:
+    - Each time the mock function is called, the full argument list is saved in a file in the
+      workspace. This is optional and depends on your task's workspace name (If your task does not require a workspace, you don't need to add this).
+      It allows us to check mock calls after task execution in our test pipeline.
+    - In this case the function touches a file that would otherwise be created by the actual `cosign`
+      call. This is specific to the task and will depend on your use case.
+    - Note: In the example above, the function being mocked is `cosign`. If that function was actually something
+      that had a hyphen in its name (e.g. `my-cool-function`), the tests would fail with
+      `my-cool-function: not a valid identifier` messages. This is because when you use `#!/usr/bin/env sh`, Bash
+      runs in POSIX mode in which case hyphens are not permitted in function names. The solution to this is to use
+      `#!/bin/bash` or `#!/usr/bin/env bash` in place of `#!/usr/bin/env sh` at the top of the file. Keep in mind
+      that the same shell declaration should be used in both the mock and the tekton task step script you are
+      mocking to ensure the behavior during test is the same as during runtime.
+
+1. In your `pre-apply-task-hook.sh` file (see the Test Setup section above for explanation), include
+    `yq` commands to inject the `mocks.sh` file to the top of your task step scripts, e.g.:
+
+    ```sh
+    #!/usr/bin/env sh
+
+    TASK_PATH=$1
+    SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+    yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' $TASK_PATH
+    yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' $TASK_PATH
+    ```
+
+    In this case we inject the file to both steps in the task under test. This will depend on
+    the given task. You only need to inject mocks for the steps where something needs to be mocked.
+
+1. (Optional) In your test pipeline, you can have a task after the main task under test that will
+    check that the mock functions had the expected calls. This only applies if you saved your mock
+    calls to a file. In our example, it will look something like this:
+
+    ```sh
+    if [ $(cat $(workspaces.data.path)/mock_cosign.txt | wc -l) != 2 ]; then
+      echo Error: cosign was expected to be called 2 times. Actual calls:
+      cat $(workspaces.data.path)/mock_cosign.txt
+      exit 1
+    fi
+    ```
+
+Note: The approach described above shows the recommended approach. But there may be variations
+depending on your needs. For example, you could have several mocks files and inject different
+files to different steps in your task.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# community-catalog
+# Community Catalog
+
+This repository contains a collection of tenant release tasks and pipelines, created and maintained by users.
+
+If you have a tenant task/pipeline or final pipeline you think would be useful to others, feel free to contribute it here.
+
+For instructions on how to use tenant tasks/pipelines and final pipelines, take a look at the [Konflux docs](https://konflux-ci.dev/docs/releasing/tenant-release-pipelines/).
+
+Note: Tasks and pipelines in this repository are **not** maintained by the release team. If there is a problem in one of the tasks or pipelines, try using a
+different branch, ask one of the task/pipeline owners, or submit a fix yourself (check [CONTRIBUTING.md](CONTRIBUTING.md) if you wish to contribute code).
+
+## Resources
+
+Here's a brief overview of what you can find in the different directories of this catalog:
+
+`pipelines`: This directory contains tenant and final pipelines that can be used in a release plan.
+`tasks`: The tasks directory holds Tekton Tasks that can be used in tenant or final pipelines.
+
+## Linting of yaml files
+
+Whenever a change is pushed to this repository and a pull request is created, a yaml lint task will run to ensure that the
+resource definition doesn't contain invalid yaml data. Refer to the [.yamllint file](.yamllint) to see the exact applied
+rules. For more information on yamllint, check the [official documentation](https://yamllint.readthedocs.io/en/stable).
+
+## Promotions
+
+The branches in this repo are automatically promoted every week on Wednesday at 14:15 UTC. Any commits in `staging` will be promoted to `production`,
+and any commits in `development` will be promoted to `staging`.
+
+All pull requests will be merged to `development`, promotions are the only way to push changes to the `staging` and `production` branches.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,5 @@
+## Describe your changes
+
+## Checklist before requesting a review
+- [ ] My commit message includes `Signed-off-by: My name <email>`
+- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)


### PR DESCRIPTION
## Describe your changes
Added LICENSE, CONTRIBUTING.md and updated README.md. The documentation for the automatic README generator is included in this PR as well.

## Checklist before requesting a review
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
