### PR TITLE
feat(CNF-20666): separate auth logic from validate-fbc pipeline

### DIFF
--- a/pipelines/validate-fbc-images-resolvable/README.md
+++ b/pipelines/validate-fbc-images-resolvable/README.md
@@ -24,7 +24,7 @@ The primary goal of this integration test is to ensure the integrity of an FBC i
 | `REPO_TOKEN` | The name of a Kubernetes Secret containing the access token needed to clone a private Git repository. | Yes | `""` | 
 | `REPO_KEY` | The key within the `REPO_TOKEN` secret that holds the access token value. | Yes | `""` | 
 | `RETRIES` | The maximum number of validation attempts for the validation task. | Yes | `"3"` | 
-| `RETRY_INTERVAL` | The time to wait between retries for the validation task, in seconds. | Yes | `"300"` | 
+| `RETRY_INTERVAL` | The time to wait between retries for the validation task, in seconds. | Yes | `"600"` | 
 
 ## How It Works
 

--- a/pipelines/validate-fbc-images-resolvable/README.md
+++ b/pipelines/validate-fbc-images-resolvable/README.md
@@ -28,27 +28,42 @@ The primary goal of this integration test is to ensure the integrity of an FBC i
 
 ## How It Works
 
-This repository contains two main components:
+This repository contains three main components:
 
-1. **`validate-fbc-images-resolvable` (Task)**: A custom Tekton `Task` that contains the core validation logic. It installs dependencies and runs the validation script against a given FBC image and IDMS content.
+1. **`validate-fbc-images-resolvable` (Task)**: A custom Tekton `Task` that contains the core validation logic. It takes pre-combined authentication data and runs the validation script against a given FBC image and IDMS content.
 
-2. **`validate-fbc-images-resolvable` (Pipeline)**: A Tekton `Pipeline` that orchestrates the entire validation process by chaining together several tasks:
+2. **`combine-dockercfgjson-secrets` (Task)**: A custom Tekton `Task` that combines multiple Docker config JSON secrets into a single authentication configuration. It reads secrets from the cluster and merges them into a unified auth file.
+
+3. **`validate-fbc-images-resolvable` (Pipeline)**: A Tekton `Pipeline` that orchestrates the entire validation process by chaining together several tasks:
 
    * **`parse-metadata`**: Extracts the FBC image URL and source Git repository details from the `SNAPSHOT` parameter.
 
-   * **`fetch-idms-file`**: Downloads the `ImageDigestMirrorSet` file from the source repository. It can use the `REPO_TOKEN` and `REPO_KEY` parameters to authenticate with private repositories.
+   * **`download-idms-file`**: Downloads the `ImageDigestMirrorSet` file from the source repository. It can use the `REPO_TOKEN` and `REPO_KEY` parameters to authenticate with private repositories.
 
-   * **`run-fbc-validation`**: Executes the `validate-fbc-images-resolvable` custom `Task`, passing the FBC image and the fetched IDMS content as parameters.
+   * **`combine-dockercfgjson-secrets`**: Reads and combines multiple Docker config JSON secrets from the cluster into a single authentication configuration.
+
+   * **`run-fbc-validation`**: Executes the `validate-fbc-images-resolvable` custom `Task`, passing the FBC image, the fetched IDMS content, and the combined authentication data as parameters.
 
 ## Dependencies
 
-The validation task runs on a `registry.access.redhat.com/ubi9/ubi:latest` base image and installs the following tools:
+The pipeline uses multiple tasks, each with their own dependencies:
+
+### validate-fbc-images-resolvable task
+Runs on a `registry.access.redhat.com/ubi9/ubi:latest` base image and installs:
 
 * **`opm v1.52.0`**: Used to render the FBC and list its contents.
-
 * **`skopeo`**: Used to inspect remote container images and verify their availability.
+* **`jq`**: Used to parse JSON and validate authentication data.
+* **`yq v4.45.4`**: Used to parse the IDMS YAML content.
 
-* **`jq`**: Used to parse the `SNAPSHOT` JSON.
+### combine-dockercfgjson-secrets task
+Runs on a `registry.access.redhat.com/ubi9/ubi:latest` base image and installs:
+
+* **`jq`**: Used to parse and merge authentication JSON data.
+* **`kubectl`**: Used to read authentication secrets from the Kubernetes cluster.
+
+### parse-metadata task
+Uses inline `jq` to parse the `SNAPSHOT` JSON parameter.
 
 ## Configuration and Usage
 
@@ -130,6 +145,6 @@ This format will cause the error: `ERROR: AUTH_SECRETS must be a valid JSON arra
 ### Requirements
 
 - Each secret must be a valid Kubernetes `dockerconfigjson` secret
-- The pipeline requires RBAC permissions to read secrets from the specified namespaces
+- The pipeline requires RBAC permissions to read secrets from the specified namespaces (used by the `combine-dockercfgjson-secrets` task)
 - Multiple secrets will be merged into a single authentication configuration
 - The AUTH_SECRETS parameter must be valid JSON format

--- a/pipelines/validate-fbc-images-resolvable/validate-fbc-images-resolvable.yaml
+++ b/pipelines/validate-fbc-images-resolvable/validate-fbc-images-resolvable.yaml
@@ -98,7 +98,6 @@ spec:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
     - name: download-idms-file
-      runAfter: [ "parse-metadata" ]
       taskRef:
         resolver: "git"
         params:
@@ -119,8 +118,21 @@ spec:
           value: $(params.REPO_TOKEN)
         - name: REPO_KEY
           value: $(params.REPO_KEY)
+    - name: combine-dockercfgjson-secrets
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/community-catalog.git
+          - name: revision
+            value: development
+          - name: pathInRepo
+            value: tasks/combine-dockercfgjson-secrets/combine-dockercfgjson-secrets.yaml
+      params:
+        - name: auth-secrets
+          value: $(params.AUTH_SECRETS)
     - name: run-fbc-validation
-      runAfter: [ "download-idms-file" ]
+      runAfter: [ "parse-metadata", "download-idms-file", "combine-dockercfgjson-secrets" ]
       taskRef:
         resolver: "git"
         params:
@@ -135,8 +147,8 @@ spec:
           value: $(tasks.parse-metadata.results.fbc-image)
         - name: idms-content
           value: $(tasks.download-idms-file.results.content)
-        - name: auth-secrets
-          value: $(params.AUTH_SECRETS)
+        - name: auth-json
+          value: $(tasks.combine-dockercfgjson-secrets.results.auth-json)
         - name: retries
           value: $(params.RETRIES)
         - name: retry-interval

--- a/pipelines/validate-fbc-images-resolvable/validate-fbc-images-resolvable.yaml
+++ b/pipelines/validate-fbc-images-resolvable/validate-fbc-images-resolvable.yaml
@@ -54,7 +54,7 @@ spec:
     - name: RETRY_INTERVAL
       description: The time to wait between retries for the validation task, in seconds.
       type: string
-      default: "300"
+      default: "600"
   tasks:
     - name: parse-metadata
       taskSpec:

--- a/tasks/combine-dockercfgjson-secrets/OWNERS
+++ b/tasks/combine-dockercfgjson-secrets/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - abraham2512
+  - fontivan
+  - rauhersu
+  - sabbir-47
+  - shajmakh
+  - yanirq

--- a/tasks/combine-dockercfgjson-secrets/README.md
+++ b/tasks/combine-dockercfgjson-secrets/README.md
@@ -1,0 +1,128 @@
+# Combine Docker Config JSON Secrets
+
+This task combines multiple Docker config JSON secrets into one.
+
+## Description
+
+This task takes in a JSON array of secret names and namespaces, reads each secret from the cluster, decodes and validates it, then merges its contents with an existing `auths` object in a single output file.
+
+
+## Parameters
+
+| Name             | Description                                                 | Optional | Default value |
+| :--------------- | :---------------------------------------------------------- | :------- | :------------ |
+| `auth-secrets`   | JSON array of secret name/namespace pairs for registry authentication. Must be provided as a valid JSON string. | Yes      | `"[]"`        |
+
+## Results
+| Name             | Description                                                 |
+| :--------------- | :---------------------------------------------------------- |
+| `auth-json`       | The combined JSON string content of the provided secrets.         | 
+
+## Dependencies
+
+The task runs on a `registry.access.redhat.com/ubi9/ubi:latest` base image and installs the following tools:
+
+*   **`jq`**: Used to parse the `snapshot` JSON and merge authentication data.
+
+*   **`kubectl`**: Used to read authentication secrets from the Kubernetes cluster.
+
+## Usage Example
+
+This task is designed to be used as a step within a larger Tekton Pipeline. The pipeline is responsible for providing the required parameters, such as the FBC image and the content of the IDMS file.
+
+Here is an example of how to call this task from a `Pipeline`, overriding the default retry settings:
+
+```yaml
+- name: combine-dockercfgjson-secrets
+  taskRef:
+    name: combine-dockercfgjson-secrets
+  params:
+    - name: auth-secrets
+      value: |
+        [
+          {
+            "name": "registry-redhat-secret",
+            "namespace": "my-namespace"
+          },
+          {
+            "name": "quay-secret",
+            "namespace": "my-namespace"
+          },
+          {
+            "name": "stage-registry-secret",
+            "namespace": "another-namespace"
+          }
+        ]
+```
+
+### Authentication Secrets Example
+
+Registry authentication secrets should be of type `kubernetes.io/dockerconfigjson`. Here's an example of creating such a secret:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-redhat-secret
+  namespace: my-namespace
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: |
+    ewogICJhdXRocyI6IHsKICAgICJyZWdpc3RyeS5yZWRoYXQuaW8iOiB7CiAgICAgICJhdXRoIjogImJhc2U2NGVuY29kZWRjcmVkZW50aWFscyIKICAgIH0KICB9Cn0K
+```
+
+## RBAC Requirements
+
+The task requires RBAC permissions to read secrets from the specified namespaces. The service account running this task needs the following permissions:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: validate-fbc-secret-reader
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: validate-fbc-secret-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: validate-fbc-secret-reader
+subjects:
+- kind: ServiceAccount
+  name: your-service-account
+  namespace: your-namespace
+```
+
+Alternatively, you can use namespace-specific roles if the secrets are in the same namespace as the task:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: validate-fbc-secret-reader
+  namespace: your-namespace
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: validate-fbc-secret-reader-binding
+  namespace: your-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: validate-fbc-secret-reader
+subjects:
+- kind: ServiceAccount
+  name: your-service-account
+  namespace: your-namespace
+```

--- a/tasks/combine-dockercfgjson-secrets/combine-dockercfgjson-secrets.yaml
+++ b/tasks/combine-dockercfgjson-secrets/combine-dockercfgjson-secrets.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: combine-dockercfgjson-secrets
+spec:
+  description: This task combines multiple Docker config JSON secrets into one JSON string.
+  params:
+    - name: auth-secrets
+      description: >-
+        JSON array of secret name/namespace pairs for registry authentication.
+        Must be provided as a valid JSON string.
+      type: string
+      default: "[]"
+  results:
+    - name: auth-json
+      description: The combined JSON content of the provided secrets.
+  steps:
+    - name: combine-secrets
+      image: registry.access.redhat.com/ubi9/ubi:latest
+      env:
+        - name: SECRETS
+          value: "$(params.auth-secrets)"
+      script: |
+        #!/usr/bin/env bash
+
+        echo "--- Installing Dependencies ---"
+        # Install jq
+        dnf install -y jq
+
+        # Install kubectl
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        chmod +x kubectl
+        mv kubectl /usr/local/bin/
+
+        # Check if secrets are provided
+        if [[ -z "$SECRETS" ]]; then
+          echo "WARNING: No secret names or namespaces provided"
+          echo '{"auths": {}}' > "$(results.auth-json.path)"
+          exit 0
+        fi
+
+        # Validate JSON format
+        SECRET_COUNT=$(echo "$SECRETS" | jq 'length')
+        if ! echo "$SECRETS" | jq . > /dev/null 2>&1; then
+          echo "ERROR: SECRETS must be a valid JSON array"
+          exit 1
+        fi
+
+        # Check if secrets array is empty
+        if [[ "$SECRET_COUNT" -eq 0 ]]; then
+          echo "WARNING: Empty secrets array provided"
+          echo '{"auths": {}}' > "$(results.auth-json.path)"
+          exit 0
+        fi
+
+        # Initialize output file
+        echo '{"auths": {}}' > /tmp/combined_auth.json
+
+        # Process each secret
+        for ((i=0; i<SECRET_COUNT; i++)); do
+          SECRET_NAME=$(echo "$SECRETS" | jq -r ".[$i].name")
+          SECRET_NAMESPACE=$(echo "$SECRETS" | jq -r ".[$i].namespace")
+
+          echo "Processing secret $((i+1)) of $SECRET_COUNT: ${SECRET_NAME} in namespace ${SECRET_NAMESPACE}"
+
+          # Read the secret from the cluster
+          if ! kubectl get secret "$SECRET_NAME" -n "${SECRET_NAMESPACE}" \
+            -o jsonpath='{.data.\.dockerconfigjson}' > "/tmp/secret_${i}_b64.txt" 2>/dev/null; then
+            echo "WARNING: Failed to read secret ${SECRET_NAME} in namespace ${SECRET_NAMESPACE}"
+            continue
+          fi
+
+          # Check if the secret data is empty
+          if [[ ! -s "/tmp/secret_${i}_b64.txt" ]]; then
+            echo "WARNING: Secret ${SECRET_NAME} contains no dockerconfigjson data"
+            continue
+          fi
+
+          # Decode the base64 content (cross-platform approach)
+          if ! base64 -d < "/tmp/secret_${i}_b64.txt" > "/tmp/secret_${i}.json" 2>/dev/null; then
+            echo "WARNING: Failed to decode secret ${SECRET_NAME} - not a valid dockerconfigjson secret"
+            continue
+          fi
+
+          # Validate it's a valid JSON
+          if ! jq . "/tmp/secret_${i}.json" > /dev/null 2>&1; then
+            echo "WARNING: Secret ${SECRET_NAME} does not contain valid JSON"
+            continue
+          fi
+
+          # Merge with existing auth file using jq
+          jq -s '
+            .[0] as $base |
+            .[1] as $new |
+            $base + {
+              "auths": ($base.auths + $new.auths)
+            }
+          ' /tmp/combined_auth.json "/tmp/secret_${i}.json" > /tmp/combined_auth_new.json
+
+          # Update the output file
+          mv /tmp/combined_auth_new.json /tmp/combined_auth.json
+          echo "Merged secret ${SECRET_NAME} into combined json"
+        done
+
+        # Validate final result
+        if ! jq . /tmp/combined_auth.json > /dev/null 2>&1; then
+          echo "ERROR: Final combined auth JSON is invalid"
+          exit 1
+        fi
+
+        echo "Combined authentication complete."
+        echo -n "$(cat /tmp/combined_auth.json)" > "$(results.auth-json.path)"

--- a/tasks/combine-dockercfgjson-secrets/tests/mocks.sh
+++ b/tasks/combine-dockercfgjson-secrets/tests/mocks.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -eux
+
+# mocks to be injected into task step scripts
+
+function dnf() {
+  echo "Mock dnf called with: $*"
+  if [[ "$*" == *"install"* ]]; then
+    echo "Package installation successful"
+  fi
+}
+
+function curl() {
+  echo "Mock curl called with: $*"
+  local url=""
+  local output=""
+  local use_remote_name=false
+  
+  # Parse arguments to find URL and output file
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -o)
+        output="$2"
+        shift 2
+        ;;
+      -O)
+        use_remote_name=true
+        shift
+        ;;
+      -LO)
+        use_remote_name=true
+        shift
+        ;;
+      -L)
+        shift
+        ;;
+      -s)
+        shift
+        ;;
+      http*)
+        url="$1"
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  
+  # For -O flag, extract filename from URL
+  if [[ "$use_remote_name" == true && -z "$output" ]]; then
+    output=$(basename "$url")
+  fi
+  
+  # Mock downloading based on URL patterns
+  if [[ "$url" == *"kubectl"* ]]; then
+    # Create a mock kubectl binary with the logic directly embedded
+    cat > "$output" << 'EOF'
+#!/bin/bash
+echo "Mock kubectl called with: $*"
+
+# Parse kubectl get secret command
+if [[ "$*" == *"get secret"* && "$*" == *"jsonpath"* ]]; then
+  # Extract secret name and namespace
+  secret_name=""
+  namespace="default"
+  args=("$@")
+  
+  for ((i=0; i<${#args[@]}; i++)); do
+    if [[ "${args[i]}" == "secret" ]]; then
+      secret_name="${args[i+1]}"
+    elif [[ "${args[i]}" == "-n" ]]; then
+      namespace="${args[i+1]}"
+    fi
+  done
+  
+  # Mock different secret scenarios
+  if [[ "$secret_name" == "non-existent-secret" ]]; then
+    echo "Error from server (NotFound): secrets \"non-existent-secret\" not found" >&2
+    exit 1
+  elif [[ "$secret_name" == "empty-secret" ]]; then
+    # Return empty data for empty-secret to test the warning case
+    echo ""
+    exit 0
+  elif [[ "$secret_name" == "test-registry-secret"* ]]; then
+    # Return different mock auth based on secret name
+    if [[ "$secret_name" == "test-registry-secret-1" ]]; then
+      mock_auth='{"auths":{"registry.example.com":{"auth":"dGVzdHVzZXIxOnRlc3RwYXNzMQ=="}}}'
+    elif [[ "$secret_name" == "test-registry-secret-2" ]]; then
+      mock_auth='{"auths":{"quay.io":{"auth":"dGVzdHVzZXIyOnRlc3RwYXNzMg=="}}}'
+    elif [[ "$secret_name" == "test-registry-secret-3" ]]; then
+      mock_auth='{"auths":{"registry.redhat.io":{"auth":"dGVzdHVzZXIzOnRlc3RwYXNzMw=="}}}'
+    else
+      mock_auth='{"auths":{"registry.example.com":{"auth":"dGVzdHVzZXI6dGVzdHBhc3M="}}}'
+    fi
+    echo -n "$mock_auth" | base64 -w 0
+  else
+    echo "Error from server (NotFound): secrets \"$secret_name\" not found" >&2
+    exit 1
+  fi
+else
+  # Default mock behavior for other kubectl commands
+  echo "Mock kubectl executed successfully"
+fi
+EOF
+    chmod +x "$output"
+  elif [[ "$url" == *"stable.txt"* ]]; then
+    # Mock the kubectl version endpoint
+    echo "v1.28.0"
+  fi
+}
+
+function chmod() {
+  echo "Mock chmod called with: $*"
+  # Use real chmod for functionality
+  command chmod "$@"
+}
+
+function mv() {
+  echo "Mock mv called with: $*"
+  command mv "$@"
+}
+
+function jq() {
+  echo "Mock jq called with: $*" >&2
+  
+  if [[ "$*" == "length" ]]; then
+    # Mock length for AUTH_SECRETS JSON array
+    # Read from stdin to determine test scenario
+    local input
+    input=$(cat)
+    
+    # Count the number of auth secrets based on test scenario
+    if [[ "$input" == *"test-registry-secret-1"* && "$input" == *"test-registry-secret-2"* ]]; then
+      echo "2"
+    elif [[ "$input" == *"test-registry-secret"* ]]; then
+      echo "1"
+    else
+      echo "0"
+    fi
+  elif [[ "$*" == *"-r"* && "$*" == *".namespace"* ]]; then
+    # Mock extracting namespace based on array index
+    if [[ "$*" == *".[0].namespace"* ]]; then
+      echo "default"
+    elif [[ "$*" == *".[1].namespace"* ]]; then
+      echo "test-namespace"
+    elif [[ "$*" == *".[2].namespace"* ]]; then
+      echo "default"
+    else
+      echo "default"
+    fi
+  elif [[ "$*" == *"-r"* && "$*" == *".name"* ]]; then
+    # Mock extracting secret name based on array index
+    if [[ "$*" == *".[0].name"* ]]; then
+      echo "test-registry-secret-1"
+    elif [[ "$*" == *".[1].name"* ]]; then
+      echo "test-registry-secret-2"
+    elif [[ "$*" == *".[2].name"* ]]; then
+      echo "empty-secret"
+    else
+      echo "test-registry-secret"
+    fi
+  elif [[ "$*" == *"-s"* ]]; then
+    # Mock merging auth files
+    local input
+    input=$(cat)
+    
+    # Return merged JSON based on input
+    if [[ "$input" == *"test-registry-secret-1"* ]]; then
+      echo '{"auths":{"registry.example.com":{"auth":"dGVzdHVzZXIxOnRlc3RwYXNzMQ=="},"quay.io":{"auth":"dGVzdHVzZXIyOnRlc3RwYXNzMg=="}}}'
+    else
+      echo '{"auths":{"registry.example.com":{"auth":"dGVzdHVzZXI6dGVzdHBhc3M="}}}'
+    fi
+  elif [[ "$*" == "." ]]; then
+    # Mock JSON validation
+    local input
+    input=$(cat)
+    
+    # Only fail validation for the specific invalid-json test case
+    if [[ "$input" == "invalid-json" ]]; then
+      echo "parse error: Invalid numeric literal at line 2, column 0" >&2
+      return 1
+    fi
+    
+    # Return the input for valid JSON
+    echo "$input"
+  else
+    echo "Mock jq result"
+  fi
+}
+
+function echo() {
+  command echo "$@"
+}
+
+function cut() {
+  command cut "$@"
+}
+
+function sort() {
+  command sort "$@"
+}
+
+function uniq() {
+  command uniq "$@"
+}
+
+function mapfile() {
+  # mapfile is a bash builtin, not available on all systems
+  # Simple implementation for testing
+  local array_name="$2"
+  eval "$array_name=()"
+  while IFS= read -r line; do
+    if [[ -n "$line" ]]; then
+      eval "$array_name+=('$line')"
+    fi
+  done
+}
+
+function uname() {
+  if [[ "$*" == "-m" ]]; then
+    echo "x86_64"
+  else
+    command uname "$@"
+  fi
+}
+
+function base64() {
+  if [[ "$*" == "-d" ]]; then
+    # Mock base64 decode - read from stdin and return mock JSON
+    read -r input
+    echo '{"auths":{"registry.example.com":{"auth":"dGVzdHVzZXI6dGVzdHBhc3M="}}}'
+  else
+    command base64 "$@"
+  fi
+} 

--- a/tasks/combine-dockercfgjson-secrets/tests/pre-apply-task-hook.sh
+++ b/tasks/combine-dockercfgjson-secrets/tests/pre-apply-task-hook.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -x
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+# Clean up any existing temporary files
+rm -f /tmp/mock_*.txt 

--- a/tasks/combine-dockercfgjson-secrets/tests/test-combine-dockercfgjson-secrets-empty-data.yaml
+++ b/tasks/combine-dockercfgjson-secrets/tests/test-combine-dockercfgjson-secrets-empty-data.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-combine-dockercfgjson-secrets-empty-data
+spec:
+  description: |
+    Test combination with empty secret data (should handle gracefully)
+  tasks:
+    - name: run-task
+      taskRef:
+        name: combine-dockercfgjson-secrets
+      params:
+        - name: auth-secrets
+          value: |
+            [
+              {
+                "name": "test-registry-secret",
+                "namespace": "default"
+              },
+              {
+                "name": "empty-secret",
+                "namespace": "default"
+              }
+            ] 

--- a/tasks/combine-dockercfgjson-secrets/tests/test-combine-dockercfgjson-secrets-empty.yaml
+++ b/tasks/combine-dockercfgjson-secrets/tests/test-combine-dockercfgjson-secrets-empty.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-combine-dockercfgjson-secrets-empty
+spec:
+  description: |
+    Test combination with empty secrets array (should fail)
+  tasks:
+    - name: run-task
+      taskRef:
+        name: combine-dockercfgjson-secrets
+      params:
+        - name: auth-secrets
+          value: "[]" 

--- a/tasks/combine-dockercfgjson-secrets/tests/test-combine-dockercfgjson-secrets-invalid-base64.yaml
+++ b/tasks/combine-dockercfgjson-secrets/tests/test-combine-dockercfgjson-secrets-invalid-base64.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-combine-dockercfgjson-secrets-invalid-base64
+spec:
+  description: |
+    Test combination with invalid base64 data (should handle gracefully)
+  tasks:
+    - name: run-task
+      taskRef:
+        name: combine-dockercfgjson-secrets
+      params:
+        - name: auth-secrets
+          value: |
+            [
+              {
+                "name": "test-registry-secret",
+                "namespace": "default"
+              },
+              {
+                "name": "invalid-secret",
+                "namespace": "default"
+              }
+            ] 

--- a/tasks/combine-dockercfgjson-secrets/tests/test-combine-dockercfgjson-secrets-invalid-json.yaml
+++ b/tasks/combine-dockercfgjson-secrets/tests/test-combine-dockercfgjson-secrets-invalid-json.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-combine-dockercfgjson-secrets-invalid-json
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Test combination with invalid JSON input (should fail with proper error)
+  tasks:
+    - name: run-task
+      taskRef:
+        name: combine-dockercfgjson-secrets
+      params:
+        - name: auth-secrets
+          value: "invalid-json" 

--- a/tasks/combine-dockercfgjson-secrets/tests/test-combine-dockercfgjson-secrets-missing-secret.yaml
+++ b/tasks/combine-dockercfgjson-secrets/tests/test-combine-dockercfgjson-secrets-missing-secret.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-combine-dockercfgjson-secrets-missing-secret
+spec:
+  description: |
+    Test combination with non-existent secret (should handle gracefully)
+  tasks:
+    - name: run-task
+      taskRef:
+        name: combine-dockercfgjson-secrets
+      params:
+        - name: auth-secrets
+          value: |
+            [
+              {
+                "name": "test-registry-secret",
+                "namespace": "default"
+              },
+              {
+                "name": "non-existent-secret",
+                "namespace": "default"
+              }
+            ] 

--- a/tasks/combine-dockercfgjson-secrets/tests/test-combine-dockercfgjson-secrets-single-secret.yaml
+++ b/tasks/combine-dockercfgjson-secrets/tests/test-combine-dockercfgjson-secrets-single-secret.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-combine-dockercfgjson-secrets-single-secret
+spec:
+  description: |
+    Test successful combination of a single Docker config JSON secret
+  tasks:
+    - name: run-task
+      taskRef:
+        name: combine-dockercfgjson-secrets
+      params:
+        - name: auth-secrets
+          value: |
+            [
+              {
+                "name": "test-registry-secret",
+                "namespace": "default"
+              }
+            ] 

--- a/tasks/combine-dockercfgjson-secrets/tests/test-combine-dockercfgjson-secrets-success.yaml
+++ b/tasks/combine-dockercfgjson-secrets/tests/test-combine-dockercfgjson-secrets-success.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-combine-dockercfgjson-secrets-success
+spec:
+  description: |
+    Test successful combination of multiple Docker config JSON secrets
+  tasks:
+    - name: run-task
+      taskRef:
+        name: combine-dockercfgjson-secrets
+      params:
+        - name: auth-secrets
+          value: |
+            [
+              {
+                "name": "test-registry-secret-1",
+                "namespace": "default"
+              },
+              {
+                "name": "test-registry-secret-2",
+                "namespace": "test-namespace"
+              }
+            ] 

--- a/tasks/validate-fbc-images-resolvable/README.md
+++ b/tasks/validate-fbc-images-resolvable/README.md
@@ -36,7 +36,7 @@ A timeout for the entire task execution is not handled internally. For that, you
 | `idms-content`   | The string content of the `ImageDigestMirrorSet` YAML file. | No       | -             |
 | `auth-json`      | JSON object containing the authentication content to use.   | Yes      | `'{"auths": {}}'` |
 | `retries`        | The maximum number of validation attempts.                  | Yes      | `3`           |
-| `retry-interval` | The time to wait between retries, in seconds.               | Yes      | `300`         |
+| `retry-interval` | The time to wait between retries, in seconds.               | Yes      | `600`         |
 
 ## Dependencies
 
@@ -71,5 +71,5 @@ Here is an example of how to call this task from a `Pipeline`, overriding the de
     - name: retries
       value: "3" # The default is 3
     - name: retry-interval
-      value: "300" # The default is 300 seconds (5 minutes)
+      value: "600" # The default is 600 seconds (10 minutes)
 ```

--- a/tasks/validate-fbc-images-resolvable/README.md
+++ b/tasks/validate-fbc-images-resolvable/README.md
@@ -34,7 +34,7 @@ A timeout for the entire task execution is not handled internally. For that, you
 | :--------------- | :---------------------------------------------------------- | :------- | :------------ |
 | `fbc-image`      | The FBC image pull spec to be validated.                    | No       | -             |
 | `idms-content`   | The string content of the `ImageDigestMirrorSet` YAML file. | No       | -             |
-| `auth-secrets`   | JSON array of secret name/namespace pairs for registry authentication. Must be provided as a valid JSON string. | Yes      | `[]`          |
+| `auth-json`      | JSON object containing the authentication content to use.   | Yes      | `'{"auths": {}}'` |
 | `retries`        | The maximum number of validation attempts.                  | Yes      | `3`           |
 | `retry-interval` | The time to wait between retries, in seconds.               | Yes      | `300`         |
 
@@ -47,8 +47,6 @@ The task runs on a `registry.access.redhat.com/ubi9/ubi:latest` base image and i
 * **`skopeo`**: Used to inspect remote container images and verify their availability.
 
 * **`jq`**: Used to parse the `snapshot` JSON and merge authentication data.
-
-* **`kubectl`**: Used to read authentication secrets from the Kubernetes cluster.
 
 * **`yq v4.45.4`**: Used to parse the IDMS YAML content.
 
@@ -68,96 +66,10 @@ Here is an example of how to call this task from a `Pipeline`, overriding the de
       value: $(tasks.parse-metadata.results.fbc-image)
     - name: idms-content
       value: $(tasks.fetch-idms-file.results.idms-content)
-    - name: auth-secrets
-      value: |
-        [
-          {
-            "name": "registry-redhat-secret",
-            "namespace": "my-namespace"
-          },
-          {
-            "name": "quay-secret",
-            "namespace": "my-namespace"
-          },
-          {
-            "name": "stage-registry-secret",
-            "namespace": "another-namespace"
-          }
-        ]
+    - name: auth-json
+      value: $(tasks.combine-dockercfgjson-secrets.results.auth-json)
     - name: retries
       value: "3" # The default is 3
     - name: retry-interval
       value: "300" # The default is 300 seconds (5 minutes)
-```
-
-### Authentication Secrets Example
-
-Registry authentication secrets should be of type `kubernetes.io/dockerconfigjson`. Here's an example of creating such a secret:
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: registry-redhat-secret
-  namespace: my-namespace
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: |
-    ewogICJhdXRocyI6IHsKICAgICJyZWdpc3RyeS5yZWRoYXQuaW8iOiB7CiAgICAgICJhdXRoIjogImJhc2U2NGVuY29kZWRjcmVkZW50aWFscyIKICAgIH0KICB9Cn0K
-```
-
-## RBAC Requirements
-
-The task requires RBAC permissions to read secrets from the specified namespaces. The service account running this task needs the following permissions:
-
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: validate-fbc-secret-reader
-rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: validate-fbc-secret-reader-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: validate-fbc-secret-reader
-subjects:
-- kind: ServiceAccount
-  name: your-service-account
-  namespace: your-namespace
-```
-
-Alternatively, you can use namespace-specific roles if the secrets are in the same namespace as the task:
-
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: validate-fbc-secret-reader
-  namespace: your-namespace
-rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: validate-fbc-secret-reader-binding
-  namespace: your-namespace
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: validate-fbc-secret-reader
-subjects:
-- kind: ServiceAccount
-  name: your-service-account
-  namespace: your-namespace
 ```

--- a/tasks/validate-fbc-images-resolvable/tests/mocks.sh
+++ b/tasks/validate-fbc-images-resolvable/tests/mocks.sh
@@ -63,11 +63,6 @@ echo "yq version 4.45.4"' > "$output"
     echo '#!/bin/bash
 echo "opm version 1.52.0"' > "$output"
     chmod +x "$output"
-  elif [[ "$url" == *"kubectl"* ]]; then
-    # Create a mock kubectl binary
-    echo '#!/bin/bash
-echo "kubectl version"' > "$output"
-    chmod +x "$output"
   elif [[ "$url" == *"stable.txt"* ]]; then
     # Mock the kubectl version endpoint
     echo "v1.28.0"
@@ -183,48 +178,9 @@ function jq() {
       echo "quay.io/available/image:v1.0.0@sha256:abc123"
       echo "quay.io/available/image2:v1.0.0@sha256:def456"
     fi
-  elif [[ "$*" == "length" ]]; then
-    # Mock length for AUTH_SECRETS JSON array
-    # Read from stdin to determine test scenario
-    local input
-    input=$(cat)
-    
-    # Count the number of auth secrets based on test scenario
-    if [[ "$input" == *"test-registry-secret-1"* && "$input" == *"test-registry-secret-2"* && "$input" == *"test-registry-secret-3"* ]]; then
-      echo "3"
-    elif [[ "$input" == *"test-registry-secret"* ]]; then
-      echo "1"
-    else
-      echo "0"
-    fi
   elif [[ "$*" == *".auths | length"* ]]; then
     # Mock registry count in auth file
     echo "1"
-  elif [[ "$*" == *"-r"* && "$*" == *".namespace"* ]]; then
-    # Mock extracting namespace based on array index
-    if [[ "$*" == *".[0].namespace"* ]]; then
-      echo "default"
-    elif [[ "$*" == *".[1].namespace"* ]]; then
-      echo "test-namespace"
-    elif [[ "$*" == *".[2].namespace"* ]]; then
-      echo "default"
-    else
-      echo "default"
-    fi
-  elif [[ "$*" == *"-r"* && "$*" == *".name"* ]]; then
-    # Mock extracting secret name based on array index
-    if [[ "$*" == *".[0].name"* ]]; then
-      echo "test-registry-secret-1"
-    elif [[ "$*" == *".[1].name"* ]]; then
-      echo "test-registry-secret-2"
-    elif [[ "$*" == *".[2].name"* ]]; then
-      echo "test-registry-secret-3"
-    else
-      echo "test-registry-secret"
-    fi
-  elif [[ "$*" == *"-s"* ]]; then
-    # Mock merging auth files
-    echo '{"auths":{"registry.example.com":{"auth":"dGVzdHVzZXI6dGVzdHBhc3M="}}}'
   elif [[ "$*" == "." ]]; then
     # Mock JSON validation
     return 0
@@ -346,60 +302,5 @@ function uname() {
     echo "x86_64"
   else
     command uname "$@"
-  fi
-}
-
-function kubectl() {
-  echo "Mock kubectl called with: $*"
-  
-  # Parse kubectl get secret command
-  if [[ "$*" == *"get secret"* && "$*" == *"jsonpath"* ]]; then
-    # Extract secret name and namespace
-    local secret_name=""
-    local namespace="default"
-    local args=("$@")
-    
-    for ((i=0; i<${#args[@]}; i++)); do
-      if [[ "${args[i]}" == "secret" ]]; then
-        secret_name="${args[i+1]}"
-      elif [[ "${args[i]}" == "-n" ]]; then
-        namespace="${args[i+1]}"
-      fi
-    done
-    
-    # Mock different secret scenarios
-    if [[ "$secret_name" == "non-existent-secret" ]]; then
-      echo "Error from server (NotFound): secrets \"non-existent-secret\" not found" >&2
-      return 1
-    elif [[ "$secret_name" == "test-registry-secret"* ]]; then
-      # Return different mock auth based on secret name
-      local mock_auth
-      if [[ "$secret_name" == "test-registry-secret-1" ]]; then
-        mock_auth='{"auths":{"registry.example.com":{"auth":"dGVzdHVzZXIxOnRlc3RwYXNzMQ=="}}}'
-      elif [[ "$secret_name" == "test-registry-secret-2" ]]; then
-        mock_auth='{"auths":{"quay.io":{"auth":"dGVzdHVzZXIyOnRlc3RwYXNzMg=="}}}'
-      elif [[ "$secret_name" == "test-registry-secret-3" ]]; then
-        mock_auth='{"auths":{"registry.redhat.io":{"auth":"dGVzdHVzZXIzOnRlc3RwYXNzMw=="}}}'
-      else
-        mock_auth='{"auths":{"registry.example.com":{"auth":"dGVzdHVzZXI6dGVzdHBhc3M="}}}'
-      fi
-      echo -n "$mock_auth" | base64 -w 0
-    else
-      echo "Error from server (NotFound): secrets \"$secret_name\" not found" >&2
-      return 1
-    fi
-  else
-    # Default mock behavior for other kubectl commands
-    echo "Mock kubectl executed successfully"
-  fi
-}
-
-function base64() {
-  if [[ "$*" == "-d" ]]; then
-    # Mock base64 decode - read from stdin and return mock JSON
-    read -r input
-    echo '{"auths":{"registry.example.com":{"auth":"dGVzdHVzZXI6dGVzdHBhc3M="}}}'
-  else
-    command base64 "$@"
   fi
 } 

--- a/tasks/validate-fbc-images-resolvable/tests/test-validate-fbc-auth-empty.yaml
+++ b/tasks/validate-fbc-images-resolvable/tests/test-validate-fbc-auth-empty.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-validate-fbc-auth-empty
 spec:
   description: |
-    Test FBC validation with empty auth-secrets (no authentication)
+    Test FBC validation with empty authentication
   tasks:
     - name: run-task
       taskRef:
@@ -21,11 +21,17 @@ spec:
               name: test-mirror-set
             spec:
               imageDigestMirrors:
-                - source: registry.example.com/test
+                - source: registry.redhat.io/ubi8
                   mirrors:
-                    - mirror.example.com/test
-        - name: auth-secrets
-          value: "[]"
+                    - mirror.example.com/ubi8
+                - source: registry.redhat.io/ubi9
+                  mirrors:
+                    - mirror.example.com/ubi9
+        - name: auth-json
+          value: |
+            {
+              "auths": {}
+            }
         - name: retries
           value: "1"
         - name: retry-interval

--- a/tasks/validate-fbc-images-resolvable/tests/test-validate-fbc-auth-malformed-secret.yaml
+++ b/tasks/validate-fbc-images-resolvable/tests/test-validate-fbc-auth-malformed-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-validate-fbc-auth-missing-secret
 spec:
   description: |
-    Test FBC validation with missing authentication secret (should handle gracefully)
+    Test FBC validation with invalid authentication JSON
   tasks:
     - name: run-task
       taskRef:
@@ -21,13 +21,21 @@ spec:
               name: test-mirror-set
             spec:
               imageDigestMirrors:
-                - source: registry.example.com/test
+                - source: registry.redhat.io/ubi8
                   mirrors:
-                    - mirror.example.com/test
-        - name: auth-secrets
+                    - mirror.example.com/ubi8
+                - source: registry.redhat.io/ubi9
+                  mirrors:
+                    - mirror.example.com/ubi9
+        - name: auth-json
           value: |
-            - name: non-existent-secret
-              namespace: default
+            {
+              "auths": {
+                "registry.example.com": {
+                  "auth": "invalid_base64_auth"
+                }
+              }
+            }
         - name: retries
           value: "1"
         - name: retry-interval

--- a/tasks/validate-fbc-images-resolvable/tests/test-validate-fbc-auth-multiple-secrets.yaml
+++ b/tasks/validate-fbc-images-resolvable/tests/test-validate-fbc-auth-multiple-secrets.yaml
@@ -27,14 +27,21 @@ spec:
                 - source: registry.redhat.io/ubi8
                   mirrors:
                     - mirror.redhat.io/ubi8
-        - name: auth-secrets
+        - name: auth-json
           value: |
-            - name: test-registry-secret-1
-              namespace: default
-            - name: test-registry-secret-2
-              namespace: test-namespace
-            - name: test-registry-secret-3
-              namespace: default
+            {
+              "auths": {
+                "registry.example.com": {
+                  "auth": "dGVzdHVzZXIxOnRlc3RwYXNzMQ=="
+                },
+                "quay.io": {
+                  "auth": "dGVzdHVzZXIyOnRlc3RwYXNzMg=="
+                },
+                "registry.redhat.io": {
+                  "auth": "dGVzdHVzZXIzOnRlc3RwYXNzMw=="
+                }
+              }
+            }
         - name: retries
           value: "1"
         - name: retry-interval

--- a/tasks/validate-fbc-images-resolvable/tests/test-validate-fbc-auth-single-secret.yaml
+++ b/tasks/validate-fbc-images-resolvable/tests/test-validate-fbc-auth-single-secret.yaml
@@ -21,13 +21,21 @@ spec:
               name: test-mirror-set
             spec:
               imageDigestMirrors:
-                - source: registry.example.com/test
+                - source: registry.redhat.io/ubi8
                   mirrors:
-                    - mirror.example.com/test
-        - name: auth-secrets
+                    - mirror.example.com/ubi8
+                - source: registry.redhat.io/ubi9
+                  mirrors:
+                    - mirror.example.com/ubi9
+        - name: auth-json
           value: |
-            - name: test-registry-secret
-              namespace: default
+            {
+              "auths": {
+                "registry.example.com": {
+                  "auth": "dGVzdHVzZXI6dGVzdHBhc3M="
+                }
+              }
+            }
         - name: retries
           value: "1"
         - name: retry-interval

--- a/tasks/validate-fbc-images-resolvable/validate-fbc-images-resolvable.yaml
+++ b/tasks/validate-fbc-images-resolvable/validate-fbc-images-resolvable.yaml
@@ -16,12 +16,11 @@ spec:
       description: The FBC image pull spec to be validated.
     - name: idms-content
       description: The string content of the ImageDigestMirrorSet YAML file.
-    - name: auth-secrets
+    - name: auth-json
       description: >-
-        JSON array of secret name/namespace pairs for registry authentication.
-        Must be provided as a valid JSON string.
+        JSON object containing the authentication content to use.
       type: string
-      default: "[]"
+      default: '{"auths": {}}'
     - name: retries
       description: The maximum number of validation attempts.
       type: string
@@ -42,20 +41,15 @@ spec:
           value: "$(params.retries)"
         - name: RETRY_INTERVAL
           value: "$(params.retry-interval)"
-        - name: AUTH_SECRETS
-          value: "$(params.auth-secrets)"
+        - name: AUTH_JSON
+          value: "$(params.auth-json)"
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
 
         echo "--- Installing Dependencies ---"
-        # Install skopeo, jq, and kubectl from dnf
+        # Install skopeo and jq from dnf
         dnf install -y skopeo jq
-
-        # Install kubectl
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-        chmod +x kubectl
-        mv kubectl /usr/local/bin/
 
         # Install yq manually as it's not in the default UBI repos
         YQ_VERSION="v4.45.4"
@@ -85,90 +79,10 @@ spec:
           exit 1
         fi
 
-        # Set up authentication parameters from Kubernetes secrets
-        AUTH_PARAMS=()
-
-        # Process JSON array directly from environment variable
-        if [[ -n "$AUTH_SECRETS" ]] && [[ "$(echo "$AUTH_SECRETS" | tr -d '[:space:]')" != "" ]] && \
-           [[ "$AUTH_SECRETS" != "[]" ]]; then
-          echo "Setting up authentication from Kubernetes secrets..."
-
-          # Validate JSON format
-          if ! echo "$AUTH_SECRETS" | jq . > /dev/null 2>&1; then
-            echo "ERROR: AUTH_SECRETS must be a valid JSON array"
-            exit 1
-          fi
-          
-          # Parse the auth secrets JSON array
-          secret_count=$(echo "$AUTH_SECRETS" | jq 'length')
-          echo "Processing $secret_count authentication secret(s)..."
-
-          # Initialize merged auth file
-          echo '{"auths": {}}' > /tmp/merged_auth.json
-
-          # Process each secret
-          for ((i=0; i<secret_count; i++)); do
-            secret_name=$(echo "$AUTH_SECRETS" | jq -r ".[$i].name")
-            secret_namespace=$(echo "$AUTH_SECRETS" | jq -r ".[$i].namespace")
-
-            echo "Processing secret $((i+1)) of $secret_count: ${secret_name} in namespace ${secret_namespace}"
-
-            # Read the secret from the cluster
-            if ! kubectl get secret "$secret_name" -n "$secret_namespace" \
-              -o jsonpath='{.data.\.dockerconfigjson}' > "/tmp/secret_${i}_b64.txt" 2>/dev/null; then
-              echo "WARNING: Failed to read secret ${secret_name} in namespace ${secret_namespace}"
-              continue
-            fi
-
-            # Check if the secret data is empty
-            if [[ ! -s "/tmp/secret_${i}_b64.txt" ]]; then
-              echo "WARNING: Secret ${secret_name} contains no dockerconfigjson data"
-              continue
-            fi
-
-            # Decode the base64 content (cross-platform approach)
-            if ! base64 -d < "/tmp/secret_${i}_b64.txt" > "/tmp/secret_${i}.json" 2>/dev/null; then
-              echo "WARNING: Failed to decode secret ${secret_name} - not a valid dockerconfigjson secret"
-              continue
-            fi
-
-            # Validate it's a valid JSON
-            if ! jq . "/tmp/secret_${i}.json" > /dev/null 2>&1; then
-              echo "WARNING: Secret ${secret_name} does not contain valid JSON"
-              continue
-            fi
-
-            # Merge with existing auth file using jq
-            jq -s '
-              .[0] as $base |
-              .[1] as $new |
-              $base + {
-                "auths": ($base.auths + $new.auths)
-              }
-            ' /tmp/merged_auth.json "/tmp/secret_${i}.json" > /tmp/merged_auth_temp.json
-
-            mv /tmp/merged_auth_temp.json /tmp/merged_auth.json
-            rm "/tmp/secret_${i}_b64.txt" "/tmp/secret_${i}.json"
-          done
-
-          # Show merged registry count
-          registry_count=$(jq '.auths | length' /tmp/merged_auth.json)
-          echo "Merged authentication for $registry_count registry(ies)"
-
-          if [[ $registry_count -gt 0 ]]; then
-            AUTH_PARAMS=(--authfile /tmp/merged_auth.json)
-          else
-            echo "WARNING: No valid authentication found in any secrets"
-          fi
-        elif [[ -n "${REGISTRY_AUTH_FILE:-}" ]]; then
-          echo "Using existing auth file: ${REGISTRY_AUTH_FILE}"
-          AUTH_PARAMS=(--authfile "${REGISTRY_AUTH_FILE}")
-        elif [[ -n "${REGISTRY_USERNAME:-}" && -n "${REGISTRY_PASSWORD:-}" ]]; then
-          echo "Using username/password authentication"
-          AUTH_PARAMS=(--creds "${REGISTRY_USERNAME}:${REGISTRY_PASSWORD}")
-        fi
-
-        echo "Authentication setup: ${AUTH_PARAMS[*]:-"No authentication"}"
+        # Configure authentication from input parameters
+        echo "$AUTH_JSON" > /tmp/auth.json
+        REGISTRY_AUTH_FILE="/tmp/auth.json"
+        AUTH_PARAMS=(--authfile "${REGISTRY_AUTH_FILE}")
 
         # Helper function to check if error is authentication-related
         is_auth_error() {

--- a/tasks/validate-fbc-images-resolvable/validate-fbc-images-resolvable.yaml
+++ b/tasks/validate-fbc-images-resolvable/validate-fbc-images-resolvable.yaml
@@ -28,7 +28,7 @@ spec:
     - name: retry-interval
       description: The time to wait between retries, in seconds.
       type: string
-      default: "300"  # 5 minutes
+      default: "600"  # 10 minutes
   steps:
     - name: validate
       image: registry.access.redhat.com/ubi9/ubi:latest


### PR DESCRIPTION
- separate the authentication combination logic into its own task
- invoke the task as part of the larger pipeline
- fix parallel task execution in the larger pipeline
- additionally, bump the timeout to account for releases sometimes being slow (up to ~30 minutes in extreme cases)
