### PR TITLE
fix: fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ different branch, ask one of the task/pipeline owners, or submit a fix yourself 
 Here's a brief overview of what you can find in the different directories of this catalog:
 
 `pipelines`: This directory contains tenant and final pipelines that can be used in a release plan.
+
 `tasks`: The tasks directory holds Tekton Tasks that can be used in tenant or final pipelines.
 
 ## Linting of yaml files


### PR DESCRIPTION
## Describe your changes
The "resources" section in the README.md is currently missing a newline between `tasks` and `pipelines`, causing them to appear on the same line on GitHub. This PR fixes this issue.


## Checklist before requesting a review
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
