### PR TITLE
feat: option to skip attestations in push-snapshot-to-quay

### DIFF
--- a/pipelines/push-snapshot-to-quay/push-snapshot-to-quay.yaml
+++ b/pipelines/push-snapshot-to-quay/push-snapshot-to-quay.yaml
@@ -34,6 +34,10 @@ spec:
       description: Only push if the managed release status is successful
       type: string
       default: "false"
+    - name: copyAllAttestations
+      description: If true, copy all discoverable attestations and signatures
+      type: string
+      default: "true"
   tasks:
     - name: push-snapshot-to-quay
       taskRef:
@@ -54,3 +58,5 @@ spec:
           value: $(params.release)
         - name: requireSuccessfulManagedRelease
           value: $(params.requireSuccessfulManagedRelease)
+        - name: copyAllAttestations
+          value: $(params.copyAllAttestations)

--- a/tasks/push-snapshot-to-quay/README.md
+++ b/tasks/push-snapshot-to-quay/README.md
@@ -15,3 +15,4 @@ contains a status indicating that a managed pipeline has successfully completed.
 | releasePlan                     | Namespaced name of release plan - should be in format "namespace/name" | No       | -             |
 | requireSuccessfulManagedRelease | Only push if the managed release status is successful                  | No       | -             |
 | snapshot                        | Namespaced name of snapshot - should be in format "namespace/name"     | No       | -             |
+| copyAllAttestations             | If true, copy all discoverable attestations and signatures             | Yes      | True          |

--- a/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
+++ b/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
@@ -24,6 +24,10 @@ spec:
     - name: snapshot
       description: Namespaced name of snapshot - should be in format "namespace/name"
       type: string
+    - name: copyAllAttestations
+      description:  If true, copy all discoverable attestations and signatures
+      type: string
+      default: "true"
   steps:
     - name: check-release-status
       image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
@@ -90,7 +94,11 @@ spec:
             jq -s 'reduce .[] as $item ({}; . * $item)' \
               "$SOURCE_AUTH_FILE" "$DEST_AUTH_FILE" > "$DOCKER_CONFIG"/config.json
 
-            cosign copy -f "$2" "$3:$4"
+            if [[ "$(params.copyAllAttestations)" == "false" ]]; then
+                skopeo copy --all "docker://$2" "docker://$3"
+            else
+                cosign copy -f "$2" "$3:$4"
+            fi
 
             echo "Pushed image $2 to repository $3:$4"
           else

--- a/tasks/push-snapshot-to-quay/tests/mocks.sh
+++ b/tasks/push-snapshot-to-quay/tests/mocks.sh
@@ -4,6 +4,11 @@ set -eux
 # mocks to be injected into task step scripts
 
 function cosign() {
+  if [[ "$PIPELINERUN_NAME" == "test-push-snapshot-to-quay-skip-attestations" ]]; then
+    echo "Error: cosign should not be called when copyAllAttestations is false"
+    exit 1
+  fi
+
   # mock cosign failing for the no-permission test
   if [[ "$*" == "copy -f quay.io/no-permission:tag "*":"* ]]
   then
@@ -18,9 +23,26 @@ function cosign() {
   fi
 }
 
+function skopeo() {
+  if [[ "$PIPELINERUN_NAME" != "test-push-snapshot-to-quay-skip-attestations" ]]; then
+    echo "Error: skopeo should only be called when copyAllAttestations is false"
+    exit 1
+  fi
+
+  # mock skopeo failing for the no-permission test
+  if [[ "$*" == "copy --all docker://quay.io/no-permission:tag docker://"* ]]; then
+    echo Invalid credentials for quay.io/no-permission:tag
+    return 1
+  fi
+
+  if [[ "$*" != "copy --all docker://quay.io/valid-repo:tag docker://quay.io/default-repo2" ]]; then
+    echo "Error: Unexpected call to skopeo: $*"
+    exit 1
+  fi
+}
+
 function kubectl() {
-  if [[ "$*" == *"snapshot"* ]]
-  then
+  if [[ "$*" == *"snapshot"* ]]; then
     if [[ "$3" == "nopermission" ]]; then
       TEST_IMAGE="quay.io/no-permission:tag"
     elif [[ "$3" == "skip-image" ]]; then

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-skip-attestations.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-skip-attestations.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-to-quay-skip-attestations
+spec:
+  description: |
+    Run the push-snapshot-to-quay task with copyAllAttestations set to false and check that the task succeeds
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-snapshot-to-quay
+      params:
+        - name: releasePlan
+          value: "ns/releasePlan"
+        - name: snapshot
+          value: "ns/snapshot"
+        - name: release
+          value: "ns/snapshot-release"
+        - name: requireSuccessfulManagedRelease
+          value: "false"
+        - name: copyAllAttestations
+          value: "false"


### PR DESCRIPTION
The `cosign` command by default copies over all of the attestations (provenance, SBOMs, etc). For OCP, we have a usecase where we are pushing our FBC builds to a custom quay repo as part of a `final` pipeline, using `push-snapshot-to-quay`. In that repo, we only want the images themselves and not the additional attestations, since in the long run, it can quickly fill up, and our custom tasks in our internal pipeline which is retrieving builds from there, will get slower with time.

Hence proposing to use `skopeo` as an option for us and other teams, who want to copy just the images.