### PR TITLE
feat: option to skip copying att and sig in push-snapshot-to-quay

### DIFF
--- a/pipelines/push-snapshot-to-quay/push-snapshot-to-quay.yaml
+++ b/pipelines/push-snapshot-to-quay/push-snapshot-to-quay.yaml
@@ -34,6 +34,10 @@ spec:
       description: Only push if the managed release status is successful
       type: string
       default: "false"
+    - name: skipAttestations
+      description: If true, skip copying attestations and signatures
+      type: string
+      default: "false"
   tasks:
     - name: push-snapshot-to-quay
       taskRef:
@@ -54,3 +58,5 @@ spec:
           value: $(params.release)
         - name: requireSuccessfulManagedRelease
           value: $(params.requireSuccessfulManagedRelease)
+        - name: skipAttestations
+          value: $(params.skipAttestations)

--- a/tasks/push-snapshot-to-quay/README.md
+++ b/tasks/push-snapshot-to-quay/README.md
@@ -15,3 +15,4 @@ contains a status indicating that a managed pipeline has successfully completed.
 | releasePlan                     | Namespaced name of release plan - should be in format "namespace/name" | No       | -             |
 | requireSuccessfulManagedRelease | Only push if the managed release status is successful                  | No       | -             |
 | snapshot                        | Namespaced name of snapshot - should be in format "namespace/name"     | No       | -             |
+| skipAttestations                | If true, skip copying attestations and signatures                      | Yes      | False         |

--- a/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
+++ b/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
@@ -24,6 +24,10 @@ spec:
     - name: snapshot
       description: Namespaced name of snapshot - should be in format "namespace/name"
       type: string
+    - name: skipAttestations
+      description: If true, skip copying attestations and signatures
+      type: string
+      default: "false"
   steps:
     - name: check-release-status
       image: quay.io/konflux-ci/release-service-utils:066a63d25546239e79533b99c83ff521a045c819
@@ -90,7 +94,11 @@ spec:
             jq -s 'reduce .[] as $item ({}; . * $item)' \
               "$SOURCE_AUTH_FILE" "$DEST_AUTH_FILE" > "$DOCKER_CONFIG"/config.json
 
-            cosign copy -f "$2" "$3:$4"
+            if [[ "$(params.skipAttestations)" == "true" ]]; then
+                skopeo copy --all "docker://$2" "docker://$3"
+            else
+                cosign copy -f "$2" "$3:$4"
+            fi
 
             echo "Pushed image $2 to repository $3:$4"
           else

--- a/tasks/push-snapshot-to-quay/tests/mocks.sh
+++ b/tasks/push-snapshot-to-quay/tests/mocks.sh
@@ -18,9 +18,20 @@ function cosign() {
   fi
 }
 
-function kubectl() {
-  if [[ "$*" == *"snapshot"* ]]
+function skopeo() {
+  # Mock skopeo for testing copyAllAttestations=false
+  if [[ "$*" == "copy --all docker://"* ]]
   then
+    echo "Skopeo copy executed (no attestations)"
+    return 0
+  fi
+  
+  echo "Error: Unexpected skopeo call: $*"
+  exit 1
+}
+
+function kubectl() {
+  if [[ "$*" == *"snapshot"* ]]; then
     if [[ "$3" == "nopermission" ]]; then
       TEST_IMAGE="quay.io/no-permission:tag"
     elif [[ "$3" == "skip-image" ]]; then

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-skip-attestations-false.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-skip-attestations-false.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-to-quay-skip-attestations-false
+spec:
+  description: |
+    Run the push-snapshot-to-quay task with skipAttestations=false 
+    and check that cosign copy is used (default behavior)
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-snapshot-to-quay
+      params:
+        - name: releasePlan
+          value: "ns/releasePlan"
+        - name: snapshot
+          value: "ns/snapshot"
+        - name: release
+          value: "ns/snapshot-release"
+        - name: requireSuccessfulManagedRelease
+          value: "false"
+        - name: skipAttestations
+          value: "false"

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-skip-attestations-true.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-skip-attestations-true.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-to-quay-skip-attestations-true
+spec:
+  description: |
+    Run the push-snapshot-to-quay task with skipAttestations=true 
+    and check that skopeo copy is used instead of cosign copy
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-snapshot-to-quay
+      params:
+        - name: releasePlan
+          value: "ns/releasePlan"
+        - name: snapshot
+          value: "ns/snapshot"
+        - name: release
+          value: "ns/snapshot-release"
+        - name: requireSuccessfulManagedRelease
+          value: "false"
+        - name: skipAttestations
+          value: "true"


### PR DESCRIPTION
## Describe your changes
The `cosign` command by default copies over all of the attestations (provenance, SBOMs, etc). For OCP, we have a usecase where we are pushing our FBC builds to a custom quay repo as part of a `final` pipeline, using `push-snapshot-to-quay`. In that repo, we only want the images themselves and not the additional attestations, since in the long run, it can quickly fill up, and our custom tasks in our internal pipeline which is retrieving builds from there, will get slower with time.

Hence proposing to use `skopeo` as an option for us and other teams, who want to copy just the images.

## Checklist before requesting a review
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
