### PR TITLE
feat: add tag templating support to push-snapshot-to-quay task

### DIFF
--- a/tasks/push-snapshot-to-quay/README.md
+++ b/tasks/push-snapshot-to-quay/README.md
@@ -7,6 +7,37 @@ each image is taken from the '.spec.data.mapping' section of the release plan, i
 If `requireSuccessfulManagedRelease` is "true", the snapshot will only be pushed if it
 contains a status indicating that a managed pipeline has successfully completed.
 
+## Tag Templating
+
+Supports variable expansion in tags:
+
+* `{{ timestamp }}` - build-date label from image (timestampFormat or %s)
+* `{{ release_timestamp }}` - current time (timestampFormat or %s)  
+* `{{ git_sha }}` - git sha from snapshot
+* `{{ git_short_sha }}` - git sha (7 chars)
+* `{{ incrementer }}` - next sequential number (e.g. v1.0.0-2 → v1.0.0-3)
+* `{{ labels.mylabel }}` - image label value
+
+### Example
+
+```yaml
+spec:
+  data:
+    mapping:
+      defaults:
+        tags:
+          - "{{ git_short_sha }}"
+          - "latest"
+        timestampFormat: "%Y%m%d"
+      components:
+        - name: my-component
+          repository: quay.io/my-org/my-repo
+          tags:
+            - "2.9.0-{{ incrementer }}"
+            - "2.9.0-{{ timestamp }}"
+            - "2.9.0-{{ git_short_sha }}"
+```
+
 ## Parameters
 
 | Name                            | Description                                                            | Optional | Default value |

--- a/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
+++ b/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
@@ -11,6 +11,8 @@ spec:
     
     If `requireSuccessfulManagedRelease` is "true", the snapshot will only be pushed if it
     contains a status indicating that a managed pipeline has successfully completed.
+    
+    Supports tag templating with variables like {{ git_short_sha }}, {{ timestamp }}, etc.
   params:
     - name: release
       description: Namespaced name of release - should be in format "namespace/name"
@@ -116,22 +118,49 @@ spec:
         fi
 
         for ((i = 0; i < NUM_COMPONENTS; i++)); do
-
           COMPONENT=$(echo -n "$SNAPSHOT_SPEC" | jq -c --argjson i "$i" '.components[$i]')
           NAME=$(jq -r '.name' <<< "$COMPONENT")
           COMPONENT_DESTINATION=$(echo -n "$RP_DATA" | jq -c --arg c "$NAME" '.components[] | select(.name == $c)')
-
-          if [[ "$COMPONENT_DESTINATION" == "" ]]; then
-            echo "No mapping for ${NAME}. Skipping."
-            continue
-          fi
-
+          [[ "$COMPONENT_DESTINATION" == "" ]] && { echo "No mapping for ${NAME}. Skipping."; continue; }
           CONTAINER_IMAGE=$(jq -r '.containerImage' <<< "$COMPONENT")
           REPOSITORY=$(jq -r '.repository' <<< "$COMPONENT_DESTINATION")
-          IMAGE_TAGS=$(jq -r '.tags' <<< "$COMPONENT_DESTINATION")
 
-          for TAG in $(jq -r '.[]' <<< "$IMAGE_TAGS"); do
-            push_image "$NAME" "$CONTAINER_IMAGE" "$REPOSITORY" "$TAG"
+          git_sha=$(jq -r '.source.git.revision' <<< "$COMPONENT")
+          all_tags=$(jq -n \
+            --argjson d "$(jq '.defaults.tags//[]' <<< "$RP_DATA")" \
+            --argjson t "$(jq '.tags//[]' <<< "$COMPONENT_DESTINATION")" \
+            '$d+$t|unique')
+          for tag in $(jq -r '.[]' <<< "$all_tags"); do
+            # Basic templating
+            tag="${tag//\{\{ git_short_sha \}\}/${git_sha:0:7}}"
+            tag="${tag//\{\{ git_sha \}\}/$git_sha}"
+            # If tag needs image metadata, do inspection for all templating
+            if [[ "$tag" == *"{{ timestamp }}"* || "$tag" == *"{{ release_timestamp }}"* || \
+                  "$tag" == *"{{ labels."* ]]; then
+              aj="$(get-image-architectures "$CONTAINER_IMAGE")"
+              im="$(skopeo inspect --retry-times 3 --no-tags \
+                --override-os "$(jq -rs 'map(.platform.os)|.[0]' <<< "$aj")" \
+                --override-arch "$(jq -rs 'map(.platform.architecture)|.[0]' <<< "$aj")" \
+                docker://"$CONTAINER_IMAGE"|jq -c)"
+              tf=$(jq -r --arg d "$(jq -r '.defaults.timestampFormat//"%s"' <<< "$RP_DATA")" \
+                '.timestampFormat//$d' <<< "$COMPONENT_DESTINATION")
+              # Apply all templating using the image metadata
+              build_date=$(jq -r '.Labels."build-date"//.Created//""' <<< "$im")
+              timestamp_value=$([ -n "$build_date" ] && date -d "$build_date" "+$tf" || echo "")
+              tag="${tag//\{\{ timestamp \}\}/$timestamp_value}"
+              tag="${tag//\{\{ release_timestamp \}\}/$(date "+$tf")}"
+              while [[ $tag =~ \{\{\ *labels\.([[:alnum:]_-]+)\ *\}\} ]]; do
+                label_value=$(jq -r --arg l "${BASH_REMATCH[1]}" '.Labels[$l]//""' <<< "$im")
+                tag="${tag//\{\{ labels.${BASH_REMATCH[1]} \}\}/$label_value}"
+              done
+            fi
+            # Incrementer templating
+            if [[ "$tag" == *"{{ incrementer }}"* ]]; then
+              vp="${tag//\{\{ incrementer \}\}/}"
+              mn=$(skopeo list-tags --retry-times 3 docker://"$REPOSITORY" 2>/dev/null | \
+                jq -r '.Tags[]' | grep -E "^${vp}[0-9]+$" | sed -E "s/${vp}//" | sort -nr | head -n1)
+              tag="${tag//\{\{ incrementer \}\}/$((mn + 1))}"
+            fi
+            push_image "$NAME" "$CONTAINER_IMAGE" "$REPOSITORY" "$tag"
           done
-
         done

--- a/tasks/push-snapshot-to-quay/tests/mocks.sh
+++ b/tasks/push-snapshot-to-quay/tests/mocks.sh
@@ -30,6 +30,7 @@ function kubectl() {
     fi
 
     EXTRA_COMPONENTS=""
+    GIT_SOURCE=""
     if [[ "$3" == "multiple" ]]; then
       EXTRA_COMPONENTS=',
       {
@@ -43,6 +44,13 @@ function kubectl() {
       {
         "containerImage": "quay.io/valid-repo2:skip-image",
         "name": "test-image4"
+      }'
+    elif [[ "$3" == "templated" ]]; then
+      GIT_SOURCE=',
+      "source": {
+        "git": {
+          "revision": "abcdef1234567890abcdef1234567890abcdef12"
+        }
       }'
     fi
 
@@ -77,7 +85,7 @@ EOF
           "components": [
             {
               "containerImage": "$TEST_IMAGE",
-              "name": "test-image"
+              "name": "test-image"$GIT_SOURCE
             }$EXTRA_COMPONENTS
           ]
         }
@@ -100,6 +108,8 @@ EOF
     fi
 
     EXTRA_COMPONENT_DESTINATIONS=""
+    DEFAULTS_SECTION=""
+    COMPONENT_TAGS='["testtag"]'
     if [[ "$3" == "multiple" ]]; then
       EXTRA_COMPONENT_DESTINATIONS=',
       {
@@ -125,6 +135,24 @@ EOF
           "testtag"
         ]
       }'
+    elif [[ "$3" == "templated" ]]; then
+      EXTRA_COMPONENT_DESTINATIONS=''
+      COMPONENT_TAGS='[
+        "{{ git_sha }}",
+        "{{ timestamp }}",
+        "{{ release_timestamp }}",
+        "{{ labels.mylabel }}",
+        "{{ incrementer }}",
+        "v1.0.0-{{ git_short_sha }}"
+      ]'
+      DEFAULTS_SECTION=',
+      "defaults": {
+        "tags": [
+          "{{ git_short_sha }}",
+          "latest"
+        ],
+        "timestampFormat": "%Y%m%d"
+      }'
     fi
 
     cat > /tmp/mock-releaseplan.json <<EOF
@@ -143,11 +171,9 @@ EOF
               {
                 "name": "test-image",
                 "repository": "$TEST_REPO",
-                "tags": [
-                  "testtag"
-                ]
+                "tags": $COMPONENT_TAGS
               }$EXTRA_COMPONENT_DESTINATIONS
-            ]
+            ]$DEFAULTS_SECTION
           }
         }
       }
@@ -235,6 +261,61 @@ EOF
     fi
   fi
 
+}
+
+function get-image-architectures() {
+  cat <<EOF
+[
+  {
+    "platform": {
+      "architecture": "amd64",
+      "os": "linux"
+    }
+  }
+]
+EOF
+}
+
+function skopeo() {
+  if [[ "$*" == *"list-tags"* ]]; then
+    cat <<EOF
+{
+  "Repository": "quay.io/default-repo2",
+  "Tags": [
+    "testtag-1",
+    "testtag-2",
+    "latest"
+  ]
+}
+EOF
+  elif [[ "$*" == *"inspect"* ]]; then
+    cat <<EOF
+{
+  "Name": "quay.io/valid-repo:tag",
+  "Created": "2023-01-01T00:00:00Z",
+  "Labels": {
+    "build-date": "2023-01-01T00:00:00Z",
+    "mylabel": "myvalue"
+  }
+}
+EOF
+  else
+    echo Mock skopeo called with: $*
+    echo Error: Unexpected call
+    exit 1
+  fi
+}
+
+function date() {
+  if [[ "$*" == *"+%Y%m%d %T"* ]]; then
+    echo "20230101 00:00:00"
+  elif [[ "$*" == *"+%Y%m%d"* ]]; then
+    echo "20230101"
+  elif [[ "$*" == *"+%s"* ]]; then
+    echo "1672531200"
+  else
+    command date "$@"
+  fi
 }
 
 function oras() {

--- a/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-templated-tags.yaml
+++ b/tasks/push-snapshot-to-quay/tests/test-push-snapshot-to-quay-templated-tags.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-to-quay-templated-tags
+spec:
+  description: Test templated tags
+  tasks:
+    - name: run-task
+      taskRef:
+        name: push-snapshot-to-quay
+      params:
+        - name: releasePlan
+          value: "ns/templated"
+        - name: snapshot
+          value: "ns/templated"
+        - name: release
+          value: "ns/snapshot-release"
+        - name: requireSuccessfulManagedRelease
+          value: "false"


### PR DESCRIPTION
- Implement tag templating with variables: {{ git_short_sha }}, {{ timestamp }}, {{ incrementer }}, etc.
- Add support for image label expansion: {{ labels.name }}
- Include defaults.tags and component-specific tags processing
- Enhance test mocks with new templating functions
- Add templated tags test case
- Update README with templating documentation

Enables community tenants to use templated tags without requiring access to managed registry credentials. Fixes MCE/ACM release pipeline issues with konflux-ci registry authentication.

Addresses templating functionality gap identified in konflux Slack thread ([KFLUXSPRT-3679](https://issues.redhat.com//browse/KFLUXSPRT-3679)).

Signed-off-by: Erin Murphy <erinmurp@redhat.com>

## Describe your changes

## Checklist before requesting a review
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
