### PR TITLE
feat(CNF-18773): Update Jira issue status on staging builds

### DIFF
--- a/pipelines/update-jira-issues-pipeline/OWNERS
+++ b/pipelines/update-jira-issues-pipeline/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - abraham2512
+  - fontivan
+  - rauhersu
+  - sabbir-47
+  - shajmakh
+  - yanirq

--- a/pipelines/update-jira-issues-pipeline/README.md
+++ b/pipelines/update-jira-issues-pipeline/README.md
@@ -1,0 +1,58 @@
+# update-jira-issues-pipeline
+
+Extracts JIRA issues from PR titles and updates them to a specified target state (default: ON_QA).
+
+## Description
+
+This pipeline automatically updates associated JIRA issues to a specified target state (default: "ON_QA"). It extracts JIRA issue references from the commit sha of a snapshot which contains pull request titles and adds comments with links to the snapshot where issues were fixed.
+
+The pipeline uses the `update-jira-issues` task to perform the actual JIRA updates.
+
+## Parameters
+
+| Name                    | Description                                                                                    | Optional | Default value                                         |
+|-------------------------|------------------------------------------------------------------------------------------------|----------|-------------------------------------------------------|
+
+| snapshot                | The namespaced name (namespace/name) of the snapshot                                          | No       | -                                                     |
+| taskGitUrl              | The url to the git repo where the community-catalog tasks to be used are stored              | Yes      | https://github.com/konflux-ci/community-catalog.git  |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                | Yes      | main                                                  |
+| jira_server             | The server of the Jira instance to update issues on                                           | Yes      | issues.redhat.com                                     |
+| jira_project_regex      | The regex to match the Jira project to update issues on                                       | Yes      | "OCPBUGS-[0-9]+"                                      |
+| jira_target_state       | The target Jira state to transition issues to                                               | Yes      | "ON_QA"                                               |
+| jira_skip_states        | The Jira states that should be skipped                                                      | Yes      | "Verified,Release Pending,Closed"                     |
+
+## Workspaces
+
+| Name | Description                                              |
+|------|----------------------------------------------------------|
+| data | The workspace where the snapshot spec json file resides |
+
+## Prerequisites
+
+- A secret named `konflux-jira-secret` containing a `token` key with a valid Jira access token
+- The snapshot must contain at least one component with a container image
+- The container image must have `vcs-ref` and `url` labels pointing to a valid Git repository
+- GitHub CLI (`gh`) must be available and configured for API access
+
+## How it works
+
+1. Receives a snapshot from a release pipeline
+2. Passes the snapshot to the `update-jira-issues` task
+3. The task extracts container images from all components in the snapshot
+4. For each component:
+   - Gets VCS reference and repository URL from the image labels
+   - Uses GitHub API to fetch the pull request title associated with the commit
+   - Extracts Jira issue ID from the PR title using the provided regex pattern
+   - Checks the current status of the Jira issue
+   - If the issue is in a skip state (e.g., "Verified", "Release Pending", "Closed"), skips processing
+   - If the issue is not already in the target state:
+     - Transitions the issue to the target state
+     - Adds a comment with the staging build information
+5. Continues processing remaining components
+
+## Notes
+
+- Currently only supports issues in issues.redhat.com due to authentication requirements
+- Issues in other servers will be skipped without the pipeline failing
+- The pipeline uses the default regex pattern `OCPBUGS-[0-9]+` to match Red Hat OpenShift bug tracker issues
+- Issues in skip states (default: "Verified", "Release Pending", "Closed") will be skipped without processing

--- a/pipelines/update-jira-issues-pipeline/README.md
+++ b/pipelines/update-jira-issues-pipeline/README.md
@@ -12,10 +12,11 @@ The pipeline uses the `update-jira-issues` task to perform the actual JIRA updat
 
 | Name                    | Description                                                                                    | Optional | Default value                                         |
 |-------------------------|------------------------------------------------------------------------------------------------|----------|-------------------------------------------------------|
-
+| release                 | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution | No       | -                                                     |
+| releasePlan             | The namespaced name (namespace/name) of the releasePlan                                       | No       | -                                                     |
 | snapshot                | The namespaced name (namespace/name) of the snapshot                                          | No       | -                                                     |
 | taskGitUrl              | The url to the git repo where the community-catalog tasks to be used are stored              | Yes      | https://github.com/konflux-ci/community-catalog.git  |
-| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                | Yes      | main                                                  |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                | Yes      | development                                          |
 | jira_server             | The server of the Jira instance to update issues on                                           | Yes      | issues.redhat.com                                     |
 | jira_project_regex      | The regex to match the Jira project to update issues on                                       | Yes      | "OCPBUGS-[0-9]+"                                      |
 | jira_target_state       | The target Jira state to transition issues to                                               | Yes      | "ON_QA"                                               |

--- a/pipelines/update-jira-issues-pipeline/update-jira-issues-pipeline.yaml
+++ b/pipelines/update-jira-issues-pipeline/update-jira-issues-pipeline.yaml
@@ -30,7 +30,7 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: main
+      default: development
     - name: jira_server
       type: string
       description: The server of the Jira instance to update issues on

--- a/pipelines/update-jira-issues-pipeline/update-jira-issues-pipeline.yaml
+++ b/pipelines/update-jira-issues-pipeline/update-jira-issues-pipeline.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: update-jira-issues-pipeline
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Pipeline to extract JIRA issues from PR names and update them using the update-jira-issues task.
+    This pipeline is triggered by PR merges and will:
+    1. Extract JIRA issue IDs from the PR name/title
+    2. Update the JIRA issues using the update-jira-issues task
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releasePlan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the community-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/community-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+      default: main
+    - name: jira_server
+      type: string
+      description: The server of the Jira instance to update issues on
+      default: issues.redhat.com
+    - name: jira_project_regex
+      type: string
+      description: The regex to match the Jira project to update issues on
+      default: "OCPBUGS-[0-9]+"
+    - name: jira_target_state
+      type: string
+      description: The target Jira state to transition issues to
+      default: "ON_QA"
+    - name: jira_skip_states
+      type: string
+      description: The Jira states that should be skipped
+      default: "Verified,Release Pending,Closed"
+  workspaces:
+    - name: data
+      description: The workspace where the snapshot spec json file resides
+  tasks:
+    - name: update-jira-issues
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/update-jira-issues/update-jira-issues.yaml
+      params:
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+        - name: snapshot
+          type: string
+          description: The namespaced name (namespace/name) of the snapshot
+          value: $(params.snapshot)
+        - name: jira_server
+          value: $(params.jira_server)
+        - name: jira_project_regex
+          value: $(params.jira_project_regex)
+        - name: jira_target_state
+          value: $(params.jira_target_state)
+        - name: jira_skip_states
+          value: $(params.jira_skip_states)
+      workspaces:
+        - name: data
+          workspace: release-workspace

--- a/tasks/update-jira-issues/OWNERS
+++ b/tasks/update-jira-issues/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - abraham2512
+  - fontivan
+  - rauhersu
+  - sabbir-47
+  - shajmakh
+  - yanirq

--- a/tasks/update-jira-issues/README.md
+++ b/tasks/update-jira-issues/README.md
@@ -1,0 +1,55 @@
+# update-jira-issues
+
+Updates Jira issues to a specified target state (default: ON_QA) when a staging build is released. Adds a comment to the issue with a link to the snapshot where it was fixed.
+
+## Description
+
+This task extracts Jira issue references from pull request titles in a release snapshot and updates those issues to a specified target state (default: "ON_QA"). It is designed to run after a staging build is released to automatically track issue progression.
+
+**Note:** This task currently only supports issues in issues.redhat.com due to authentication requirements. Issues in other servers will be skipped without the task failing.
+
+## Parameters
+
+| Name               | Description                                                                                    | Optional | Default value                                         |
+|-------------------|------------------------------------------------------------------------------------------------|----------|-------------------------------------------------------|
+| snapshot          | The namespaced name (namespace/name) of the snapshot                                          | No       | -                                                     |
+| jira_server       | The server of the Jira instance to update issues on                                           | Yes      | issues.redhat.com                                     |
+| jira_project_regex| The regex to match the Jira project to update issues on                                       | Yes      | "OCPBUGS-[0-9]+"                                      |
+| jira_target_state| The target Jira state to transition issues to                                               | Yes      | "ON_QA"                                               |
+| jira_skip_states| The Jira states that should be skipped                                                      | Yes      | "Verified,Release Pending,Closed"                     |
+
+## Workspaces
+
+| Name | Description                                              |
+|------|----------------------------------------------------------|
+| data | The workspace where the snapshot spec json file resides |
+
+## Prerequisites
+
+- A secret named `konflux-jira-secret` containing a `token` key with a valid Jira access token
+- The snapshot must contain at least one component with a container image
+- The container image must have `vcs-ref` and `url` labels pointing to a valid Git repository
+- GitHub CLI (`gh`) must be available and configured for API access
+
+## How it works
+
+1. Extracts container images from all components in the snapshot
+2. For each component:
+   - Gets VCS reference and repository URL from the image labels
+   - Uses GitHub API to fetch the pull request title associated with the commit
+   - Extracts Jira issue ID from the PR title using the provided regex pattern
+   - Checks the current status of the Jira issue
+   - If the issue is in a skip state (e.g., "Verified", "Release Pending", "Closed"), skips processing
+   - If the issue is not already in the target state:
+     - Transitions the issue to the target state
+     - Adds a comment with the staging build information
+   - If the issue is already in the target state, skips processing
+3. Continues processing remaining components
+
+## Behavior
+
+- **Success**: Task completes successfully when all components are processed
+- **Skip**: If no Jira issue is found in a PR title, that component is skipped and processing continues
+- **Skip**: If an issue is in a skip state or already in the target state, that component is skipped and processing continues
+- **Error**: If no container images can be extracted from the snapshot, the task exits with code 1
+- **Error**: If a component has an empty image, the task exits with code 1

--- a/tasks/update-jira-issues/tests/mocks.sh
+++ b/tasks/update-jira-issues/tests/mocks.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+# SC2016 - "Expressions don't expand in single quotes, use double quotes for that." 
+# is disabled because we need to use single quotes in some cases
+
+# shellcheck disable=SC2016
+set -eux
+
+# mocks to be injected into task step scripts
+
+function kubectl() {
+  # Don't echo debug output to avoid interfering with the actual return value
+  echo $* >> /tmp/mock_oc.txt
+
+  if [[ "$*" == *"get snapshot"* ]]; then
+    # Mock snapshot response for default/konflux-test-container-98765
+    cat > /tmp/mock_snapshot.json <<EOF
+{
+  "spec": {
+    "components": [
+      {
+        "containerImage": "quay.io/example/konflux-test-container:latest"
+      }
+    ]
+  }
+}
+EOF
+    cat /tmp/mock_snapshot.json
+  elif [[ "$*" == *"image info"* ]]; then
+    # Mock image info response
+    cat > /tmp/mock_image_info.txt <<EOF
+vcs-ref=abc123def456
+url=https://github.com/example/konflux-test-container.git
+EOF
+    cat /tmp/mock_image_info.txt
+  else
+    echo Error: Unexpected oc call: $*
+    exit 1
+  fi
+}
+
+function jq() {
+  # Don't echo debug output to avoid interfering with the actual return value
+  echo $* >> /tmp/mock_jq.txt
+
+  if [[ "$*" == *".spec.components[0].containerImage"* ]]; then
+    echo "quay.io/example/konflux-test-container:latest"
+  elif [[ "$*" == *".spec.components[].containerImage"* ]]; then
+    echo "quay.io/example/konflux-test-container:latest"
+  elif [[ "$*" == *".transitions[] | select(.name==\"ON_QA\") | .id"* ]]; then
+    echo "123"
+  elif [[ "$*" == *".fields.status.name"* ]]; then
+    echo "ON_QA"
+  elif [[ "$*" == *".servers[] | contains"* ]]; then
+    echo "rest/api/2/issue"
+  elif [[ "$*" == *".[0] | \"\\(.title)\""* ]]; then
+    echo "OCPBUGS-12345: Fix important OCP issue"
+  elif [[ "$*" == *"[] | select(.servers[] | contains"* ]]; then
+    echo "rest/api/2/issue"
+  elif [[ "$*" == *"select(.servers[] | contains"* ]]; then
+    echo "rest/api/2/issue"
+  else
+    echo Error: Unexpected jq call: $*
+    exit 1
+  fi
+}
+
+function gh() {
+  # Don't echo debug output to avoid interfering with the actual return value
+  echo $* >> /tmp/mock_gh.txt
+
+  if [[ "$*" == *"api repos"* ]]; then
+    # Mock GitHub API response for pull request
+    cat > /tmp/mock_gh_response.json <<EOF
+[
+  {
+    "title": "OCPBUGS-12345: Fix important OCP issue"
+  }
+]
+EOF
+    cat /tmp/mock_gh_response.json
+  else
+    echo Error: Unexpected gh call: $*
+    exit 1
+  fi
+}
+
+function curl-with-retry() {
+  # Don't echo debug output to avoid interfering with the actual return value
+  echo $* >> /tmp/mock_curl.txt
+
+  if [[ "$*" == *"transitions"* ]]; then
+    # Mock transitions API response
+    cat > /tmp/mock_transitions.json <<EOF
+{
+  "transitions": [
+    {
+      "id": "123",
+      "name": "ON_QA"
+    }
+  ]
+}
+EOF
+    cat /tmp/mock_transitions.json
+  elif [[ "$*" == *"rest/api/2/issue"* ]] && [[ "$*" != *"transitions"* ]] && [[ "$*" != *"comment"* ]]; then
+    # Mock issue status API response
+    cat > /tmp/mock_issue_status.json <<EOF
+{
+  "fields": {
+    "status": {
+      "name": "ON_QA"
+    }
+  }
+}
+EOF
+    cat /tmp/mock_issue_status.json
+  else
+    echo Error: Unexpected curl-with-retry call: $*
+    exit 1
+  fi
+}

--- a/tasks/update-jira-issues/tests/pre-apply-task-hook.sh
+++ b/tasks/update-jira-issues/tests/pre-apply-task-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -x
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+# Create a dummy jira secret (and delete it first if it exists)
+kubectl delete secret konflux-jira-secret --ignore-not-found
+kubectl create secret generic konflux-jira-secret --from-literal=token=dummy-token

--- a/tasks/update-jira-issues/tests/test-update-jira-issues-skip-on-qa.yaml
+++ b/tasks/update-jira-issues/tests/test-update-jira-issues-skip-on-qa.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-jira-issues-skip-on-qa
+spec:
+  description: |
+    Run the update-jira-issues task with a snapshot that results in an issue
+    already in the target state (ON_QA). The task should skip the issue and exit successfully.
+  workspaces:
+    - name: tests-workspace
+      description: The workspace provided by the CI system for testing
+  tasks:
+    - name: run-task
+      taskRef:
+        name: update-jira-issues
+      params:
+        - name: snapshot
+          value: "default/konflux-test-container-98765"
+        - name: jira_server
+          value: "issues.redhat.com"
+        - name: jira_project_regex
+          value: "OCPBUGS-[0-9]+"
+        - name: jira_target_state
+          value: "ON_QA"
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/update-jira-issues/update-jira-issues.yaml
+++ b/tasks/update-jira-issues/update-jira-issues.yaml
@@ -1,0 +1,170 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: update-jira-issues
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >
+    Tekton task to update issue to a specified target state (default: on_qa) referenced in the merge.
+    It is meant to run after a staging build is released.
+    A comment will be added to the issue with a link to the staging build it was fixed in.
+
+    Note: This task currently only supports issues in issues.redhat.com due to it requiring authentication.
+    Issues in other servers will be skipped without the task failing.
+  params:
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: jira_server
+      type: string
+      description: The server of the Jira instance to update issues on
+      default: issues.redhat.com
+    - name: jira_project_regex
+      type: string
+      description: The regex to match the Jira project to update issues on
+      default: "OCPBUGS-[0-9]+"
+    - name: jira_target_state
+      type: string
+      description: The target Jira state to transition issues to
+      default: "ON_QA"
+    - name: jira_skip_states
+      type: string
+      description: The Jira states that should be skipped
+      default: "Verified,Release Pending,Closed"
+  workspaces:
+    - name: data
+      description: The workspace where the snapshot spec json file resides
+  steps:
+    - name: update-issues
+      image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 50m
+      env:
+        - name: JIRA_ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: konflux-jira-secret
+              key: token
+      script: |
+        #!/usr/bin/env bash
+        # We do not set -x here because it would leak the ACCESS_TOKEN
+        set -eu
+
+        ISSUE_TRACKERS='{
+            "Jira": {
+                "api": "rest/api/2/issue",
+                "servers": [
+                    "issues.redhat.com",
+                    "jira.atlassian.com"
+                ]
+            },
+            "bugzilla": {
+                "api": "rest/bug",
+                "servers": [
+                    "bugzilla.redhat.com"
+                ]
+            }
+        }'
+
+        snapshotRef=$(params.snapshot)
+        jira_project_regex=$(params.jira_project_regex)
+        server=$(params.jira_server)
+        target_state=$(params.jira_target_state)
+        skip_states="$(params.jira_skip_states)"
+
+        components=$(kubectl get snapshot "$snapshotRef" -ojson | jq -r '.spec.components[].containerImage')
+        # Loop through all components
+        for image in $components; do
+          # Check if image is empty and exit if it is
+          if [ -z "$image" ]; then
+              echo "No image found in snapshot: $snapshotRef"
+              exit 1
+          fi
+
+          echo "snapshot: $snapshotRef"
+          echo "image: $image"
+
+          vcs_ref=$(kubectl image info "$image" | grep vcs-ref | awk -F'=' '{print $2}' | tr -d ' ')
+          repo_url=$(kubectl image info "$image" | grep url | awk -F'=' '{print $2}' | \
+            sed 's|https://github.com/||' | sed 's|\.git$||' | tr -d ' ')
+
+          echo "vcs_ref: $vcs_ref"
+          echo "repo_url: $repo_url"
+
+          title=$(gh api repos/"$repo_url"/commits/"$vcs_ref"/pulls | jq -r '.[0] | "\(.title)"')
+
+          issue=$(echo "$title" | grep -o -E "$jira_project_regex")
+
+          # Check if issue is empty and exit if it is
+          if [ -z "$issue" ]; then
+              echo "No issue found in PR title: $title"
+              exit 0
+          fi
+
+          echo "repo_url: $repo_url"
+          echo "vcs_ref: $vcs_ref"
+          echo "title: $title"
+          echo "issue: $issue"
+          echo "server: $server"
+
+          CURL_ARGS=(
+              -H "Authorization: Bearer $JIRA_ACCESS_TOKEN"
+              --retry 3
+          )
+
+          API=$(jq -r '.[] | select(.servers[] | contains("'"$server"'")) | .api' <<< "$ISSUE_TRACKERS")
+          API_URL="https://$server/${API}/$issue"
+
+          # Get current status once to avoid multiple API calls
+          current_status=$(curl-with-retry "${CURL_ARGS[@]}" "${API_URL}" | jq -r '.fields.status.name')
+
+          if [ "$current_status" == "$target_state" ]; then
+              echo "Issue $issue is already in $target_state state. Skipping it."
+              exit 0
+          fi
+
+          # Check if current status matches any skip state
+          IFS=',' read -ra skip_states_array <<< "$skip_states"
+          for state in "${skip_states_array[@]}"; do
+              # Trim whitespace from state
+              trimmed_state=$(echo "$state" | xargs)
+              echo "Debug: Comparing '$current_status' with '$trimmed_state'"
+              if [ "$current_status" == "$trimmed_state" ]; then
+                  echo "Issue $issue is in '$trimmed_state' state. Skipping it."
+                  exit 0
+              fi
+          done
+
+          echo "Updating issue $issue"
+          BUILD_COMMENT="Bug fix is available in snapshot: $snapshotRef"
+          STATUS_RC=0
+          # Get the target state transition id. This varies per Jira project
+          if ! STATUS_ID="$(curl-with-retry "${CURL_ARGS[@]}" "${API_URL}/transitions" \
+              | jq -er '.transitions[] | select(.name=="'"$target_state"'") | .id')"; then
+              echo "Warning: failed to fetch the $target_state state id for issue $issue." \
+                  "We most likely do not have permission to update it."
+              STATUS_RC=1
+          fi
+          # Update the issue with staging build
+          if [ "$STATUS_RC" -ne 1 ] ; then
+              # Transition status
+              if ! curl-with-retry "${CURL_ARGS[@]}" -XPOST --data \
+              '{"transition":{"id":"'"$STATUS_ID"'"}}' \
+              -H "Content-Type: application/json" "${API_URL}/transitions"; then
+              echo "Warning: failed to update issue $issue. Will still try to add a comment."
+              fi
+              # Try to add the comment even if updating failed
+              if ! curl-with-retry "${CURL_ARGS[@]}" -XPOST --data \
+                  '{"body":"'"$BUILD_COMMENT"'"}' \
+                  -H "Content-Type: application/json" "${API_URL}/comment"; then
+                  echo "Warning: failed to add comment to issue $issue."
+              fi
+          fi
+        done


### PR DESCRIPTION
## Describe your changes
This PR updates ocpbug jira status to ON_QA after builds are pushed to staging

Here is a breakdown of the flow,

1. The PR that triggered the merge is identified from the snapshot metadata
2. The PR's title is assumed to have a OCPBUGS-xxxxx header, and if present, the jira item is retrieved from it
3. The identified jira item is moved from any status to ON_QA. If it is already in ON_QA, it is skipped

Assisted by: Cursor + Claude Code

## Checklist before requesting a review
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
