### PR TITLE
feat(RELEASE-1880): rework update-internal-services-manager pipeline

### DIFF
--- a/pipelines/update-internal-services-manager/README.md
+++ b/pipelines/update-internal-services-manager/README.md
@@ -1,7 +1,7 @@
 # update-internal-services-manager pipeline
 
 Tekton pipeline to update the internal-services manager yaml to the latest image in the
-hacbs-release/app-interface-deployments repository.
+github.com/redhat-appstudio/infra-common-deployments repository.
 
 ## Parameters
 

--- a/pipelines/update-internal-services-manager/update-internal-services-manager.yaml
+++ b/pipelines/update-internal-services-manager/update-internal-services-manager.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   description: |-
     Tekton pipeline to update the internal-services manager yaml to the latest image in the
-    hacbs-release/app-interface-deployments repository.
+    github.com/redhat-appstudio/infra-common-deployments repository.
   params:
     - name: release
       type: string
@@ -46,10 +46,8 @@ spec:
           - name: pathInRepo
             value: tasks/update-manager-image-in-git/update-manager-image-in-git.yaml
       params:
-        - name: mode
-          value: push
-        - name: repoBranch
-          value: main
+        - name: deployment
+          value: staging
         - name: repoUrl
           value: $(params.repoUrl)
         - name: githubSecret
@@ -67,10 +65,8 @@ spec:
           - name: pathInRepo
             value: tasks/update-manager-image-in-git/update-manager-image-in-git.yaml
       params:
-        - name: mode
-          value: pr
-        - name: repoBranch
-          value: stable
+        - name: deployment
+          value: production
         - name: repoUrl
           value: $(params.repoUrl)
         - name: githubSecret

--- a/tasks/update-manager-image-in-git/README.md
+++ b/tasks/update-manager-image-in-git/README.md
@@ -1,15 +1,12 @@
 # update-manager-image-in-git
 
-Updates the image line in the manager yaml files in the internal-services/manager directory.
-If mode is `pr`, a pull request is created for the update. If mode is `push`, the change is pushed
-directly.
+Updates the image line in the manager yaml files in the internal-services component directories.
 
 ## Parameters
 
-| Name         | Description                                                                                   | Optional | Default value                                          |
-|--------------|-----------------------------------------------------------------------------------------------|----------|--------------------------------------------------------|
-| mode         | Whether the task should create a pull request or directly push. Options are [pr, push]        | No       | -                                                      |
-| repoBranch   | The branch in the repo to target                                                              | Yes      | main                                                   |
-| repoUrl      | The repo to update, starting with github.com, without https:// (e.g. github.com/org/repo.git) | Yes      | github.com/hacbs/release/app-interface-deployments.git |
-| githubSecret | The secret containing a `token` key with value set to the GitHub access token                 | No       | -                                                      |
-| image        | The manager image to update to                                                                | No       | -                                                      |
+| Name         | Description                                                                                   | Optional | Default value                                            |
+|--------------|-----------------------------------------------------------------------------------------------|----------|----------------------------------------------------------|
+| deployment   | The deployment to be updated. Options are [staging, production]                               | No       | -                                                        |
+| repoUrl      | The repo to update, starting with github.com, without https:// (e.g. github.com/org/repo.git) | Yes      | github.com/redhat-appstudio/infra-common-deployments.git |
+| githubSecret | The secret containing a `token` key with value set to the GitHub access token                 | No       | -                                                        |
+| image        | The manager image to update to                                                                | No       | -                                                        |

--- a/tasks/update-manager-image-in-git/tests/mocks.sh
+++ b/tasks/update-manager-image-in-git/tests/mocks.sh
@@ -8,11 +8,16 @@ function git() {
 
   if [[ "$*" == *"clone"* ]]; then
     gitRepo=$(awk '{print $NF}' <<< $*)
-    mkdir -p "$gitRepo"/internal-services/manager
+    mkdir -p "$gitRepo"/components/internal-services/internal-staging
     echo "image: quay.io/konflux-ci/internal-services:old" | tee \
-      "$gitRepo"/internal-services/manager/one.yaml \
-      "$gitRepo"/internal-services/manager/two.yaml \
-      "$gitRepo"/internal-services/manager/three.yaml
+      "$gitRepo"/components/internal-services/internal-staging/manager-one.yaml \
+      "$gitRepo"/components/internal-services/internal-staging/manager-two.yaml \
+      "$gitRepo"/components/internal-services/internal-staging/manager-three.yaml
+    mkdir -p "$gitRepo"/components/internal-services/internal-production
+    echo "image: quay.io/konflux-ci/internal-services:old" | tee \
+      "$gitRepo"/components/internal-services/internal-production/manager-one.yaml \
+      "$gitRepo"/components/internal-services/internal-production/manager-two.yaml \
+      "$gitRepo"/components/internal-services/internal-production/manager-three.yaml
   else
     # Mock the other git functions to pass
     : # no-op - do nothing

--- a/tasks/update-manager-image-in-git/tests/test-update-manager-fail-invalid-deployment.yaml
+++ b/tasks/update-manager-image-in-git/tests/test-update-manager-fail-invalid-deployment.yaml
@@ -2,21 +2,19 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-update-manager-fail-invalid-mode
+  name: test-update-manager-fail-invalid-deployment
   annotations:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the update-manager-image-in-git with an invalid `mode` param and ensure the task fails.
+    Run the update-manager-image-in-git with an invalid `deployment` param and ensure the task fails.
   tasks:
     - name: run-task
       taskRef:
         name: update-manager-image-in-git
       params:
-        - name: mode
+        - name: deployment
           value: other
-        - name: repoBranch
-          value: fail-branch
         - name: repoUrl
           value: github.com/org/repo
         - name: githubSecret

--- a/tasks/update-manager-image-in-git/tests/test-update-manager.yaml
+++ b/tasks/update-manager-image-in-git/tests/test-update-manager.yaml
@@ -12,10 +12,8 @@ spec:
       taskRef:
         name: update-manager-image-in-git
       params:
-        - name: mode
-          value: pr
-        - name: repoBranch
-          value: main
+        - name: deployment
+          value: staging
         - name: repoUrl
           value: github.com/org/repo
         - name: githubSecret

--- a/tasks/update-manager-image-in-git/update-manager-image-in-git.yaml
+++ b/tasks/update-manager-image-in-git/update-manager-image-in-git.yaml
@@ -8,21 +8,15 @@ metadata:
     tekton.dev/tags: "release, tenant"
 spec:
   description: |-
-      Updates the image line in the manager yaml files in the internal-services/manager directory.
-      If mode is `pr`, a pull request is created for the update. If mode is `push`, the change is pushed
-      directly.
+      Updates the image line in the manager yaml files in the internal-services component directories.
   params:
-    - name: mode
+    - name: deployment
       type: string
-      description: Whether the task should create a pull request or directly push. Options are [pr, push]
-    - name: repoBranch
-      type: string
-      description: The branch in the repo to target
-      default: main
+      description: The deployment to be updated. Options are [staging, production]
     - name: repoUrl
       type: string
       description: The repo to update, starting with github.com, without https:// (e.g. github.com/org/repo.git)
-      default: github.com/hacbs/release/app-interface-deployments.git
+      default: github.com/redhat-appstudio/infra-common-deployments.git
     - name: githubSecret
       type: string
       description: The secret containing a `token` key with value set to the GitHub access token
@@ -52,13 +46,15 @@ spec:
           #!/usr/bin/env bash
           set -euxo pipefail
 
-          if ! [[ "$(params.mode)" =~ ^(push|pr)$ ]] ; then
-              echo "Invalid mode parameter. Only 'pr' and 'push' are allowed."
+          if ! [[ "$(params.deployment)" =~ ^(staging|production)$ ]] ; then
+              echo "Invalid deployment parameter. Only 'staging' and 'production' are allowed."
               exit 1
           fi
 
           # Switch to /tmp to avoid filesystem permission issues
           cd /tmp
+
+          BASE_BRANCH=main
 
           set +x
           git clone "https://oauth2:$GITHUB_TOKEN@$(params.repoUrl)" gitRepo
@@ -66,25 +62,27 @@ spec:
           cd gitRepo
           git config --global user.name "$NAME"
           git config --global user.email "$EMAIL"
-          git checkout "$(params.repoBranch)"
+          git checkout "$BASE_BRANCH"
 
-          BRANCH=$(params.repoBranch)
-          if [ "$(params.mode)" = "pr" ] ; then
-              BRANCH="automated-manager-update"
-              git checkout -b "$BRANCH"
-          fi
+          BRANCH="internal-services-$(params.deployment)-manager-update"
+          git checkout -b "$BRANCH"
 
           # Perform substitution
-          find internal-services/manager -type f -name "*.yaml" -exec \
+          find "components/internal-services/internal-$(params.deployment)" -type f -name "manager-*.yaml" -exec \
             sed -i "s|quay.io/konflux-ci/internal-services:.*|$(params.image)|" {} \;
 
           git add .
-          TITLE="chore: update manager image in $(params.repoBranch)"
+          TITLE="chore: update internal-services manager images for $(params.deployment)"
           git commit -m "$TITLE"
           git push -f origin "$BRANCH"
 
-          if [ "$(params.mode)" = "pr" ] ; then
-              # This command will fail if there is already an open PR. In this case, the push before this
-              # will update the PR so it is okay if this fails
-              gh pr create --base "$(params.repoBranch)" --head "$BRANCH" --title "$TITLE" --body "" || true
+          # This command will fail if there is already an open PR. In this case, the push before this
+          # will update the PR so it is okay if this fails
+          PR_URL=$(gh pr create --base "$BASE_BRANCH" --head "$BRANCH" --title "$TITLE" --body "" || echo "")
+          if [[ -n "$PR_URL" ]]; then
+              # If a new PR was created and deployment is staging, add /lgtm and /approve comments so it automerges
+              if [[ "$(params.deployment)" == "staging" ]]; then
+                  gh pr comment "$PR_URL" --body "/lgtm"
+                  gh pr comment "$PR_URL" --body "/approve"
+              fi
           fi


### PR DESCRIPTION
This commit reworks the update-internal-services-manager pipeline and its main task, update-manager-in-git. The repo to change was updated (including a new directory structure) and both staging and prod will be updated with PRs now instead of a direct commit to staging.

## Describe your changes

## Checklist before requesting a review
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
