### PR TITLE
chore: fix indentation in update-internal-services task

### DIFF
--- a/tasks/update-internal-services/update-internal-services.yaml
+++ b/tasks/update-internal-services/update-internal-services.yaml
@@ -87,7 +87,7 @@ spec:
               yq -i ".subjects += {\"kind\": \"Group\", \"name\": \"konflux-release-team\" }" \
                 components/internal-services/base/rbac/role_binding.yaml
               # Maintain the view-authenticated-users RoleBinding in kustomization.yaml
-              echo "- view-authenticated-users.yaml" >> components/internal-services/base/rbac/kustomization.yaml
+              echo "  - view-authenticated-users.yaml" >> components/internal-services/base/rbac/kustomization.yaml
           fi
 
           PREV_COMMIT=$(grep -r "quay.io/konflux-ci/internal-services:" \


### PR DESCRIPTION
The kustomization.yaml file in the internal-services repo had its indentation updated, so the line we are manually adding should be updated to match.

## Describe your changes

## Checklist before requesting a review
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
