### PR TITLE
chore: allow slack handles in release notifications

### DIFF
--- a/pipelines/notify-slack-on-failure/README.md
+++ b/pipelines/notify-slack-on-failure/README.md
@@ -11,5 +11,7 @@ Optionally, it can also send a notification on success.
 | secretKeyName   | Name of key within secret which contains webhook URL                            | No       | -                                                   |
 | release         | Namespaced name of release - should be in format "namespace/name"               | No       | -                                                   |
 | notifySuccess   | If set to "true", it will also send a notification on success.                  | Yes      | "false"                                             |
+| slackHandles    | Comma-separated list of Slack member IDs or group IDs to be tagged on failures  | Yes      | ""                                                  |
+| tagSuccess      | If set to "true", will tag users in success notifications as well (only applies when notifySuccess is true) | Yes      | "false"                                             |
 | taskGitUrl      | The url to the git repo where the community-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/community-catalog.git |
 | taskGitRevision | The revision in the taskGitUrl repo to be used                                  | No       | -                                                   |

--- a/pipelines/notify-slack-on-failure/notify-slack-on-failure.yaml
+++ b/pipelines/notify-slack-on-failure/notify-slack-on-failure.yaml
@@ -24,6 +24,16 @@ spec:
       type: string
       description: If set to "true", it will also send notification on success
       default: "false"
+    - name: slackHandles
+      type: string
+      description: Comma-separated list of Slack member IDs or group IDs to be tagged on failures
+      default: ""
+    - name: tagSuccess
+      type: string
+      description: |-
+        If set to "true", will tag users in success notifications as well
+        (only applies when notifySuccess is true)
+      default: "false"
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the community-catalog tasks to be used are stored
@@ -51,3 +61,7 @@ spec:
           value: $(params.release)
         - name: notifySuccess
           value: $(params.notifySuccess)
+        - name: slackHandles
+          value: $(params.slackHandles)
+        - name: tagSuccess
+          value: $(params.tagSuccess)

--- a/tasks/notify-slack-on-failure/README.md
+++ b/tasks/notify-slack-on-failure/README.md
@@ -5,9 +5,11 @@ Optionally, it can also send a notification on success.
 
 ## Parameters
 
-| Name          | Description                                                       | Optional | Default value |
-|---------------|-------------------------------------------------------------------|----------|---------------|
-| secretName    | Name of secret which contains authentication token for app        | No       | -             |
-| secretKeyName | Name of key within secret which contains webhook URL              | No       | -             |
-| release       | Namespaced name of release - should be in format "namespace/name" | No       | -             |
-| notifySuccess | If set to "true", it will also send notification on success       | Yes      | "false"       |
+| Name          | Description                                                                     | Optional | Default value |
+|---------------|---------------------------------------------------------------------------------|----------|---------------|
+| secretName    | Name of secret which contains authentication token for app                      | No       | -             |
+| secretKeyName | Name of key within secret which contains webhook URL                            | No       | -             |
+| release       | Namespaced name of release - should be in format "namespace/name"               | No       | -             |
+| notifySuccess | If set to "true", it will also send notification on success                     | Yes      | "false"       |
+| slackHandles  | Comma-separated list of Slack member IDs or group IDs to be tagged on failures  | Yes      | ""            |
+| tagSuccess    | If set to "true", will tag users in success notifications as well (only applies when notifySuccess is true) | Yes      | "false"       |

--- a/tasks/notify-slack-on-failure/notify-slack-on-failure.yaml
+++ b/tasks/notify-slack-on-failure/notify-slack-on-failure.yaml
@@ -17,6 +17,14 @@ spec:
     - name: notifySuccess
       description: If set to "true", it will also send notification on success
       default: "false"
+    - name: slackHandles
+      description: Comma-separated list of Slack member IDs or group IDs to be tagged on failures
+      default: ""
+    - name: tagSuccess
+      description: |-
+        If set to "true", will tag users in success notifications as well
+        (only applies when notifySuccess is true)
+      default: "false"
   volumes:
     - name: slack-token
       secret:
@@ -34,6 +42,10 @@ spec:
           value: $(params.secretKeyName)
         - name: NOTIFY_SUCCESS
           value: $(params.notifySuccess)
+        - name: SLACK_HANDLES
+          value: $(params.slackHandles)
+        - name: TAG_SUCCESS
+          value: $(params.tagSuccess)
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -63,26 +75,50 @@ spec:
 
         RELEASESTATUS=$(jq -r '.reason' <<< "$RELEASECONDITIONS")
 
+        # Build mentions string and set prefix if handles are provided and should be included
+        MENTIONS_PREFIX=""
+        if [ -n "${SLACK_HANDLES}" ] && { [[ "$RELEASESTATUS" == *"Failed"* ]] || \
+            { [[ "${NOTIFY_SUCCESS}" == "true" ]] && [[ "${TAG_SUCCESS}" == "true" ]]; }; }; then
+          # Save original IFS
+          OLD_IFS=$IFS
+          # Split by comma
+          IFS=',' read -ra HANDLES <<< "$SLACK_HANDLES"
+          MENTIONS=""
+          for handle in "${HANDLES[@]}"; do
+            # Trim whitespace from each handle
+            handle=$(echo "$handle" | xargs)
+            if [ -n "$handle" ]; then
+              if [[ "$handle" == S* ]]; then
+                # Group IDs start with S, use <!subteam^GROUP_ID> format
+                MENTION="<!subteam^$handle>"
+              else
+                # Assume it's a user ID and use <@USER_ID> format
+                MENTION="<@$handle>"
+              fi
+              MENTIONS="$MENTIONS $MENTION"
+            fi
+          done
+          # Trim leading/trailing whitespace from the final string
+          MENTIONS=$(echo "$MENTIONS" | xargs)
+          # Set prefix with mentions
+          MENTIONS_PREFIX="$MENTIONS\n\n"
+          # Restore IFS
+          IFS=$OLD_IFS
+        fi
+
+        # Extract condition message and create suffix
+        CONDITION_MESSAGE=$(jq -r '.message' <<< "$RELEASECONDITIONS" | awk NF)
+        CONDITION_SUFFIX=""
+        if [ -n "$CONDITION_MESSAGE" ]; then
+          CONDITION_SUFFIX=": \`\`\`$CONDITION_MESSAGE\`\`\`"
+        fi
+
         if [[ "$RELEASESTATUS" == *"Failed"* ]]; then
-          CONDITION_MESSAGE=$(jq -r '.message' <<< "$RELEASECONDITIONS" | awk NF)
-
-          if [ -n "$CONDITION_MESSAGE" ]; then
-            MESSAGE=$(printf "Release: %s/%s\n\nManaged pipelines failed: \`\`\`%s\`\`\`" \
-              "$RELEASE_NAMESPACE" "$RELEASE_NAME" "$CONDITION_MESSAGE")
-          else
-            MESSAGE=$(printf "Release: %s/%s\n\nManaged pipelines failed." \
-              "$RELEASE_NAMESPACE" "$RELEASE_NAME")
-          fi
+          MESSAGE=$(printf "%sRelease: %s/%s\n\nManaged pipelines failed%s" \
+            "$MENTIONS_PREFIX" "$RELEASE_NAMESPACE" "$RELEASE_NAME" "$CONDITION_SUFFIX")
         elif [[ "${NOTIFY_SUCCESS}" == "true" ]] && [[ "$RELEASESTATUS" == *"Succeeded"* ]]; then
-          CONDITION_MESSAGE=$(jq -r '.message' <<< "$RELEASECONDITIONS" | awk NF)
-
-          if [ -n "$CONDITION_MESSAGE" ]; then
-            MESSAGE=$(printf "Release: %s/%s\n\nManaged pipelines succeeded: \`\`\`%s\`\`\`" \
-              "$RELEASE_NAMESPACE" "$RELEASE_NAME" "$CONDITION_MESSAGE")
-          else
-            MESSAGE=$(printf "Release: %s/%s\n\nManaged pipelines succeeded." \
-              "$RELEASE_NAMESPACE" "$RELEASE_NAME")
-          fi
+          MESSAGE=$(printf "%sRelease: %s/%s\n\nManaged pipelines succeeded%s" \
+            "$MENTIONS_PREFIX" "$RELEASE_NAMESPACE" "$RELEASE_NAME" "$CONDITION_SUFFIX")
         else
           echo "All pipelines succeeded. Not sending notification (notifySuccess=${NOTIFY_SUCCESS})."
           exit

--- a/tasks/notify-slack-on-failure/tests/mocks.sh
+++ b/tasks/notify-slack-on-failure/tests/mocks.sh
@@ -19,25 +19,63 @@ function curl() {
     exit 1
   fi
 
-  # no workspaces to pass information along, but there's only one test that actually uses curl.
-  # if any other test manages to use curl, release is set to 'ns/success' in all other tests
-  # so they won't reproduce the error message and the test will fail
+  # Extract the actual message text from the JSON payload
+  # We distinguish test cases by the message content (release namespace/name and presence of mentions)
   ACTUAL_TEXT=$(cat /tmp/payload.json | jq -r '.text')
 
+  # Check for mentions and message content once - we'll verify them based on the test case
+  HAS_UFAIL1=$(echo "$ACTUAL_TEXT" | grep -c "<@Ufail1>" || true)
+  HAS_UFAIL2=$(echo "$ACTUAL_TEXT" | grep -c "<@Ufail2>" || true)
+  HAS_UFAIL3=$(echo "$ACTUAL_TEXT" | grep -c "<@Ufail3>" || true)
+  HAS_SFAIL1=$(echo "$ACTUAL_TEXT" | grep -c "<!subteam^Sfail1>" || true)
+  HAS_USUCCESS1=$(echo "$ACTUAL_TEXT" | grep -c "<@Usuccess1>" || true)
+  HAS_USUCCESS2=$(echo "$ACTUAL_TEXT" | grep -c "<@Usuccess2>" || true)
+  HAS_FAILURE=$(echo "$ACTUAL_TEXT" | grep -c "SAMPLE ERROR MESSAGE" || true)
+  HAS_SUCCESS=$(echo "$ACTUAL_TEXT" | grep -c "Managed pipelines succeeded" || true)
+
   # Check for message format with release namespace/name:
-  # For failure test: must contain release name and error message
-  # For success test: must contain release name and success message
-  if echo "$ACTUAL_TEXT" | grep -q "Release: ns/fail"; then
-    if ! echo "$ACTUAL_TEXT" | grep -q "SAMPLE ERROR MESSAGE"; then
-      echo Error: unexpected message
+  # Each test uses a unique release name matching the test case
+  if echo "$ACTUAL_TEXT" | grep -q "Release: ns/release-failure" && [ "$HAS_FAILURE" -eq 0 ]; then
+    echo Error: unexpected message
+    echo Actual text: "$ACTUAL_TEXT"
+    exit 1
+  fi
+
+  # Distinguish between failure test cases by release name
+  if echo "$ACTUAL_TEXT" | grep -q "Release: ns/release-failure-no-mentions"; then
+    # This test should have NO mentions
+    if [ "$HAS_UFAIL1" -gt 0 ] || [ "$HAS_UFAIL2" -gt 0 ] || [ "$HAS_UFAIL3" -gt 0 ] || [ "$HAS_SFAIL1" -gt 0 ]; then
+      echo "Error: unexpected mentions found in failure message without mentions"
       echo Actual text: "$ACTUAL_TEXT"
       exit 1
     fi
-  elif echo "$ACTUAL_TEXT" | grep -q "Release: ns/success"; then
-    if ! echo "$ACTUAL_TEXT" | grep -q "Managed pipelines succeeded"; then
-      echo Error: unexpected message
+  elif echo "$ACTUAL_TEXT" | grep -q "Release: ns/release-failure" && ! echo "$ACTUAL_TEXT" | grep -q "Release: ns/release-failure-no-mentions"; then
+    # This is the release-failure test (with mentions), verify mentions are present
+    if [ "$HAS_UFAIL1" -eq 0 ] || [ "$HAS_UFAIL2" -eq 0 ] || [ "$HAS_UFAIL3" -eq 0 ] || [ "$HAS_SFAIL1" -eq 0 ]; then
+      echo "Error: expected mentions <@Ufail1>, <@Ufail2>, <@Ufail3>, and <!subteam^Sfail1> not found"
       echo Actual text: "$ACTUAL_TEXT"
       exit 1
+    fi
+  elif (echo "$ACTUAL_TEXT" | grep -q "Release: ns/release-success-with-notify" || echo "$ACTUAL_TEXT" | grep -q "Release: ns/success-mentions-no-tag") && [ "$HAS_SUCCESS" -eq 0 ]; then
+    echo Error: unexpected message
+    echo Actual text: "$ACTUAL_TEXT"
+    exit 1
+  elif echo "$ACTUAL_TEXT" | grep -q "Release: ns/release-success-with-notify" || echo "$ACTUAL_TEXT" | grep -q "Release: ns/success-mentions-no-tag"; then
+    # Distinguish between success test cases by release name
+    if echo "$ACTUAL_TEXT" | grep -q "Release: ns/release-success-with-notify"; then
+      # This test has tagSuccess=true, mentions should be present
+      if [ "$HAS_USUCCESS1" -eq 0 ] || [ "$HAS_USUCCESS2" -eq 0 ]; then
+        echo "Error: expected mentions <@Usuccess1> and <@Usuccess2> not found in success message"
+        echo Actual text: "$ACTUAL_TEXT"
+        exit 1
+      fi
+    elif echo "$ACTUAL_TEXT" | grep -q "Release: ns/success-mentions-no-tag"; then
+      # This test has tagSuccess=false, mentions should NOT be present
+      if [ "$HAS_USUCCESS1" -gt 0 ] || [ "$HAS_USUCCESS2" -gt 0 ]; then
+        echo "Error: unexpected mentions found in success message without tagSuccess"
+        echo Actual text: "$ACTUAL_TEXT"
+        exit 1
+      fi
     fi
   else
     echo Error: unexpected message

--- a/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-release-failure-no-mentions.yaml
+++ b/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-release-failure-no-mentions.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-notify-slack-on-failure-release-failure
+  name: test-notify-slack-on-failure-release-failure-no-mentions
 spec:
   description: |
     Run the notify-slack-on-failure task with a release that
-    has failed
+    has failed but without mentions to verify no tags are included
   tasks:
     - name: run-task
       taskRef:
@@ -17,6 +17,4 @@ spec:
         - name: secretKeyName
           value: "my-team"
         - name: release
-          value: "ns/release-failure"
-        - name: slackHandles
-          value: "Ufail1, Ufail2,Ufail3,Sfail1"
+          value: "ns/release-failure-no-mentions"

--- a/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-release-success-with-mentions-no-tag-success.yaml
+++ b/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-release-success-with-mentions-no-tag-success.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-notify-slack-on-failure-release-failure
+  name: test-notify-slack-success-mentions-no-tag
 spec:
   description: |
     Run the notify-slack-on-failure task with a release that
-    has failed
+    has succeeded, with mentions but tagSuccess=false to verify no tags are included
   tasks:
     - name: run-task
       taskRef:
@@ -17,6 +17,10 @@ spec:
         - name: secretKeyName
           value: "my-team"
         - name: release
-          value: "ns/release-failure"
+          value: "ns/success-mentions-no-tag"
+        - name: notifySuccess
+          value: "true"
+        - name: tagSuccess
+          value: "false"
         - name: slackHandles
-          value: "Ufail1, Ufail2,Ufail3,Sfail1"
+          value: "Usuccess1, Usuccess2"

--- a/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-release-success-with-notify.yaml
+++ b/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-release-success-with-notify.yaml
@@ -17,6 +17,10 @@ spec:
         - name: secretKeyName
           value: "my-team"
         - name: release
-          value: "ns/success"
+          value: "ns/release-success-with-notify"
         - name: notifySuccess
           value: "true"
+        - name: tagSuccess
+          value: "true"
+        - name: slackHandles
+          value: "Usuccess1, Usuccess2"

--- a/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-release-success.yaml
+++ b/tasks/notify-slack-on-failure/tests/test-notify-slack-on-failure-release-success.yaml
@@ -17,4 +17,4 @@ spec:
         - name: secretKeyName
           value: "my-team"
         - name: release
-          value: "ns/success"
+          value: "ns/release-success"


### PR DESCRIPTION
Add option to provide list of slack handles to be mentioned in the release failure notification. By default, handles will be tagged only on release failure. Tagging on success can be enabled via a dedicated flag.

Refactored the tests a bit for clarity.

Assisted-by: Cursor

## Describe your changes

## Checklist before requesting a review
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
