### PR TITLE
fix: newline character in slack message on failure

### DIFF
--- a/tasks/notify-slack-on-failure/notify-slack-on-failure.yaml
+++ b/tasks/notify-slack-on-failure/notify-slack-on-failure.yaml
@@ -101,7 +101,7 @@ spec:
           # Trim leading/trailing whitespace from the final string
           MENTIONS=$(echo "$MENTIONS" | xargs)
           # Set prefix with mentions
-          MENTIONS_PREFIX="$MENTIONS\n\n"
+          MENTIONS_PREFIX=$(printf "%s\n\n" "$MENTIONS")
           # Restore IFS
           IFS=$OLD_IFS
         fi

--- a/tasks/notify-slack-on-failure/tests/mocks.sh
+++ b/tasks/notify-slack-on-failure/tests/mocks.sh
@@ -19,6 +19,15 @@ function curl() {
     exit 1
   fi
 
+  # Check for literal \n characters in the raw JSON (before decoding)
+  # This verifies that the JSON payload contains literal \n instead of actual newlines
+  RAW_JSON=$(cat /tmp/payload.json)
+  if echo "$RAW_JSON" | grep -q '\\\\n'; then
+    echo "Error: Found literal \\\\n in JSON payload (should be actual newlines)"
+    echo "Raw JSON: $RAW_JSON"
+    exit 1
+  fi
+
   # Extract the actual message text from the JSON payload
   # We distinguish test cases by the message content (release namespace/name and presence of mentions)
   ACTUAL_TEXT=$(cat /tmp/payload.json | jq -r '.text')


### PR DESCRIPTION
Newline characters were printed as literal "\n" in the slack message instead of creating a new line. This commit fixes that.

Assisted-by: Cursor

## Describe your changes

## Checklist before requesting a review
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
