### PR TITLE
CNF-20884: Add sha256 checksum validation to task and pipeline

### DIFF
--- a/pipelines/validate-fbc-images-resolvable/validate-fbc-images-resolvable.yaml
+++ b/pipelines/validate-fbc-images-resolvable/validate-fbc-images-resolvable.yaml
@@ -33,6 +33,10 @@ spec:
       description: The path within the source Git repository to the ImageDigestMirrorSet configuration file.
       type: string
       default: ".tekton/images-mirror-set.yaml"
+    - name: MIRROR_SET_SHA256
+      description: The SHA256 checksum of the ImageDigestMirrorSet configuration file.
+      type: string
+      default: ""
     - name: AUTH_SECRETS
       description: >-
         JSON array of secret name/namespace pairs for registry authentication.
@@ -114,6 +118,8 @@ spec:
           value: $(tasks.parse-metadata.results.source-git-revision)
         - name: pathInRepo
           value: $(params.PATH_TO_MIRROR_SET)
+        - name: sha256_checksum
+          value: $(params.MIRROR_SET_SHA256)
         - name: REPO_TOKEN
           value: $(params.REPO_TOKEN)
         - name: REPO_KEY

--- a/tasks/download-file-from-git-repo/README.md
+++ b/tasks/download-file-from-git-repo/README.md
@@ -8,19 +8,36 @@ This task is designed to download the content of a specific file from a given Gi
 
 ## Parameters
 
-| Name         | Description                                                                                             | Optional | Default value |
-| :----------- | :------------------------------------------------------------------------------------------------------ | :------- | :------------ |
-| `url`        | The base URL of the Git repository (e.g., `https://github.com/org/repo`).                               | No       | -             |
-| `revision`   | The Git revision (branch, tag, or commit SHA) where the file is located.                                | No       | -             |
-| `pathInRepo` | The full path to the file within the repository.                                                        | No       | -             |
-| `REPO_TOKEN` | The name of the Kubernetes Secret that contains an access token for a private Git repository.           | Yes      | `""`          |
-| `REPO_KEY`   | The key within the `REPO_TOKEN` secret that holds the access token value.                               | Yes      | `""`          |
+| Name             | Description                                                                                             | Optional | Default value |
+| :--------------- | :------------------------------------------------------------------------------------------------------ | :------- | :------------ |
+| `url`            | The base URL of the Git repository (e.g., `https://github.com/org/repo`).                               | No       | -             |
+| `revision`       | The Git revision (branch, tag, or commit SHA) where the file is located.                                | No       | -             |
+| `pathInRepo`     | The full path to the file within the repository.                                                        | No       | -             |
+| `sha256_checksum` | The SHA256 checksum of the file to download. If provided, the task will verify the downloaded file matches this checksum. | Yes      | `""`          |
+| `REPO_TOKEN`     | The name of the Kubernetes Secret that contains an access token for a private Git repository.           | Yes      | `""`          |
+| `REPO_KEY`       | The key within the `REPO_TOKEN` secret that holds the access token value.                               | Yes      | `""`          |
 
 ## Results
 
 | Name      | Description                         |
 | :-------- | :---------------------------------- |
 | `content` | The raw string content of the downloaded file. |
+
+## Features
+
+### Checksum Validation
+
+When the `sha256_checksum` parameter is provided, the task will automatically verify the downloaded file's SHA256 checksum against the expected value. If the checksums don't match, the task will fail with an error message showing both the expected and calculated checksums.
+
+This feature is useful for:
+- Ensuring file integrity during download
+- Detecting tampering or corruption
+- Verifying exact file versions in security-sensitive contexts
+
+To calculate the SHA256 checksum of a file:
+```bash
+sha256sum myfile.txt
+```
 
 ## Usage Example
 
@@ -44,6 +61,8 @@ This task is designed to be used as a step within a larger Tekton Pipeline. The 
       value: "my-branch"
     - name: pathInRepo
       value: "path/to/my/file.txt"
+    - name: sha256_checksum
+      value: "a1b2c3d4e5f6..." # Optional: Verify file integrity
     - name: REPO_TOKEN
       value: "my-private-repo-secret" # Only needed for private repos
     - name: REPO_KEY

--- a/tasks/download-file-from-git-repo/download-file-from-git-repo.yaml
+++ b/tasks/download-file-from-git-repo/download-file-from-git-repo.yaml
@@ -14,6 +14,10 @@ spec:
       description: The Git revision (branch, tag, or commit SHA) where the file is located.
     - name: pathInRepo
       description: The full path to the file within the repository.
+    - name: sha256_checksum
+      description: The SHA256 checksum of the file to download.
+      type: string
+      default: ""
     - name: REPO_TOKEN
       description: The name of the Kubernetes Secret that contains an access token for a private Git repository.
       type: string
@@ -31,7 +35,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
-        
+
         # Sanitize inputs to remove any potential leading/trailing whitespace, including newlines.
         CLEAN_URL=$(xargs <<< "$(params.url)")
         CLEAN_REVISION=$(xargs <<< "$(params.revision)")
@@ -39,10 +43,11 @@ spec:
 
         file_url="${CLEAN_URL}/raw/${CLEAN_REVISION}/${CLEAN_PATH}"
         echo "Attempting to fetch file from URL: ${file_url}"
-        
+
         CURL_OUTPUT=$(mktemp)
+        echo "Writing to file: $CURL_OUTPUT"
         CURL_ARGS=(-w "%{http_code}" -L -o "$CURL_OUTPUT")
-        
+
         if [[ -n "$(params.REPO_TOKEN)" ]]; then
           echo "Source repository is private, using token from secret '$(params.REPO_TOKEN)'."
           TOKEN=$(kubectl get secret "$(params.REPO_TOKEN)" -o jsonpath="{.data.$(params.REPO_KEY)}" | base64 -d)
@@ -51,7 +56,7 @@ spec:
             '$(params.REPO_TOKEN)' with key '$(params.REPO_KEY)'."
             exit 1
           fi
-          
+
           if [[ "$CLEAN_URL" == *"github.com"* ]]; then
             AUTH_HEADER="Authorization: token $TOKEN"
           elif [[ "$CLEAN_URL" == *"gitlab."* ]]; then
@@ -66,7 +71,7 @@ spec:
         fi
 
         HTTP_STATUS=$(curl "${CURL_ARGS[@]}" "$file_url")
-        
+
         if [[ "$HTTP_STATUS" -ne 200 ]]; then
             echo "ERROR: Failed to fetch file. curl responded with HTTP status: ${HTTP_STATUS}"
             echo "URL: ${file_url}"
@@ -75,14 +80,26 @@ spec:
             echo "---------------------"
             exit 1
         fi
-        
+
         file_content=$(cat "$CURL_OUTPUT")
-        
+        echo "Fetched file content:"
+        echo "$file_content"
+
         if [[ -z "$file_content" ]]; then
             echo "ERROR: Fetched file is empty, but request was successful (HTTP 200)."
             echo "URL: ${file_url}"
             exit 1
         fi
-        
+
+        if [[ -n "$(params.sha256_checksum)" ]]; then
+          calculated_checksum=$(sha256sum "$CURL_OUTPUT" | awk '{print $1}')
+          if [[ "$calculated_checksum" != "$(params.sha256_checksum)" ]]; then
+            echo "ERROR: Calculated SHA256 checksum does not match the expected checksum."
+            echo "Expected: $(params.sha256_checksum)"
+            echo "Calculated: $calculated_checksum"
+            exit 1
+          fi
+        fi
+
         echo "Successfully fetched file content."
         echo -n "$file_content" > "$(results.content.path)"

--- a/tasks/download-file-from-git-repo/tests/README.md
+++ b/tasks/download-file-from-git-repo/tests/README.md
@@ -17,6 +17,10 @@ This directory contains tests for the `download-file-from-git-repo` task.
 - `test-download-file-invalid-key.yaml` - Test handling of invalid secret keys
 - `test-download-file-unknown-provider.yaml` - Test handling of unknown git providers
 
+### Checksum Validation Tests
+- `test-download-file-valid-checksum.yaml` - Test successful download with correct SHA256 checksum verification
+- `test-download-file-invalid-checksum.yaml` - Test failure when SHA256 checksum doesn't match (expected to fail)
+
 ## Mock Functions
 
 The `mocks.sh` file contains mock implementations of:
@@ -25,6 +29,7 @@ The `mocks.sh` file contains mock implementations of:
 - `base64` - Simulates base64 encoding/decoding
 - `xargs` - Simulates whitespace trimming
 - `mktemp` - Creates temporary files for testing
+- `sha256sum` - Simulates SHA256 checksum calculation and verification
 
 ## Test Scenarios
 
@@ -40,6 +45,7 @@ The `mocks.sh` file contains mock implementations of:
 - Missing Kubernetes secret
 - Invalid secret key
 - Unknown git provider
+- Invalid SHA256 checksum (checksum mismatch)
 
 ## Mock Behavior
 
@@ -60,6 +66,12 @@ The mock functions simulate different scenarios based on URL patterns and authen
 - URLs containing `empty-test`: Return empty content
 - URLs containing `private-repo`: Require authentication
 - URLs containing `unknown-provider`: Test unknown provider handling
+
+### Checksum Mock Behavior
+The `sha256sum` mock function:
+- Returns predefined checksums for known test content patterns (public/private GitHub and GitLab files)
+- Supports both calculation mode (piped input) and verification mode (`--check` flag)
+- Validates checksums against expected values when using `--check`
 
 ## Running Tests
 

--- a/tasks/download-file-from-git-repo/tests/mocks.sh
+++ b/tasks/download-file-from-git-repo/tests/mocks.sh
@@ -6,12 +6,12 @@ set -eux
 function curl() {
   echo Mock curl called with: $* >&2
   echo $* >> /tmp/mock_curl.txt 2>&1
-  
+
   local output_file=""
   local url=""
   local auth_header=""
   local http_code_flag=false
-  
+
   # Parse arguments
   while [[ $# -gt 0 ]]; do
     case $1 in
@@ -41,7 +41,7 @@ function curl() {
         ;;
     esac
   done
-  
+
   # Determine response based on URL patterns
   if [[ "$url" == *"404-test"* ]]; then
     echo "404" # HTTP status code
@@ -178,7 +178,7 @@ function kubectl() {
       return 0
     fi
   fi
-  
+
   # Default kubectl behavior
   echo "Mock kubectl called with: $*"
 }
@@ -194,7 +194,7 @@ function base64() {
       # Read from stdin (pipe input)
       read -r input
     fi
-    
+
     case "$input" in
       "dG9rZW4tZm9yLXByaXZhdGUtcmVwbw==")
         echo "token-for-private-repo"
@@ -231,4 +231,75 @@ function mktemp() {
 function cat() {
   # Use real cat but ensure it works with our test files
   command cat "$@"
-} 
+}
+
+function sha256sum() {
+  echo "Mock sha256sum called with: $*" >&2
+
+  # Check if we're validating a checksum (--check flag)
+  if [[ "$*" == *"--check"* ]]; then
+    # Read the expected checksum from stdin
+    local check_line
+    read -r check_line
+    local expected_checksum=$(echo "$check_line" | awk '{print $1}')
+    local file=$(echo "$check_line" | awk '{print $2}')
+
+    # For test purposes, validate based on content
+    if [[ -f "$file" ]]; then
+      local content=$(cat "$file")
+      # Mock: validate based on known test patterns
+      case "$content" in
+        "public-github-file-content")
+          local actual="5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
+          ;;
+        "private-github-file-content")
+          local actual="c99a5c31c55d7c4f9e4ec3f8e3a8d8f5c7b6a5d4e3f2a1b0c9d8e7f6a5b4c3d2"
+          ;;
+        "public-gitlab-file-content")
+          local actual="a1b2c3d4e5f6789012345678901234567890123456789012345678901234567890"
+          ;;
+        "private-gitlab-file-content")
+          local actual="b2c3d4e5f67890123456789012345678901234567890123456789012345678901a"
+          ;;
+        *)
+          local actual="calculated-checksum-for-content"
+          ;;
+      esac
+
+      if [[ "$expected_checksum" == "$actual" ]]; then
+        echo "$file: OK"
+        return 0
+      else
+        echo "$file: FAILED"
+        return 1
+      fi
+    fi
+  else
+    # Calculate checksum from stdin or file
+    local input
+    if [[ -n "${1:-}" ]] && [[ -f "$1" ]]; then
+      input=$(cat "$1")
+    else
+      input=$(cat)
+    fi
+
+    # Return mock checksums based on content
+    case "$input" in
+      "public-github-file-content")
+        echo "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8  -"
+        ;;
+      "private-github-file-content")
+        echo "c99a5c31c55d7c4f9e4ec3f8e3a8d8f5c7b6a5d4e3f2a1b0c9d8e7f6a5b4c3d2  -"
+        ;;
+      "public-gitlab-file-content")
+        echo "a1b2c3d4e5f6789012345678901234567890123456789012345678901234567890  -"
+        ;;
+      "private-gitlab-file-content")
+        echo "b2c3d4e5f67890123456789012345678901234567890123456789012345678901a  -"
+        ;;
+      *)
+        echo "calculated-checksum-for-content  -"
+        ;;
+    esac
+  fi
+}

--- a/tasks/download-file-from-git-repo/tests/test-download-file-invalid-checksum.yaml
+++ b/tasks/download-file-from-git-repo/tests/test-download-file-invalid-checksum.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-download-file-invalid-checksum
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Test downloading a file with invalid SHA256 checksum (should fail)
+  tasks:
+    - name: run-task
+      taskRef:
+        name: download-file-from-git-repo
+      params:
+        - name: url
+          value: "https://github.com/org/public-repo"
+        - name: revision
+          value: "main"
+        - name: pathInRepo
+          value: "README.md"
+        - name: sha256_checksum
+          value: "0000000000000000000000000000000000000000000000000000000000000000"
+        - name: REPO_TOKEN
+          value: ""
+        - name: REPO_KEY
+          value: ""

--- a/tasks/download-file-from-git-repo/tests/test-download-file-valid-checksum.yaml
+++ b/tasks/download-file-from-git-repo/tests/test-download-file-valid-checksum.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-download-file-valid-checksum
+spec:
+  description: |
+    Test downloading a file with valid SHA256 checksum verification
+  tasks:
+    - name: run-task
+      taskRef:
+        name: download-file-from-git-repo
+      params:
+        - name: url
+          value: "https://github.com/org/public-repo"
+        - name: revision
+          value: "main"
+        - name: pathInRepo
+          value: "README.md"
+        - name: sha256_checksum
+          value: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
+        - name: REPO_TOKEN
+          value: ""
+        - name: REPO_KEY
+          value: ""

--- a/tasks/validate-fbc-images-resolvable/tests/mocks.sh
+++ b/tasks/validate-fbc-images-resolvable/tests/mocks.sh
@@ -56,7 +56,7 @@ function curl() {
   if [[ "$url" == *"yq"* ]]; then
     # Create a mock yq binary
     echo '#!/bin/bash
-echo "yq version 4.45.4"' > "$output"
+echo "yq version 4.50.1"' > "$output"
     chmod +x "$output"
   elif [[ "$url" == *"opm"* ]]; then
     # Create a mock opm binary
@@ -136,7 +136,7 @@ function yq() {
   echo "Mock yq called with: $*"
   
   if [[ "$*" == "--version" ]]; then
-    echo "yq version 4.45.4"
+    echo "yq version 4.50.1"
     return 0
   fi
   
@@ -299,8 +299,30 @@ function mapfile() {
 
 function uname() {
   if [[ "$*" == "-m" ]]; then
-    echo "x86_64"
+    # Default to x86_64, but allow override via environment variable for testing
+    echo "${MOCK_ARCH:-x86_64}"
   else
     command uname "$@"
+  fi
+}
+
+function sha256sum() {
+  echo "Mock sha256sum called with: $*" >&2
+  
+  # Check if we're validating a checksum (--check flag)
+  if [[ "$*" == *"--check"* ]]; then
+    # Read expected checksum and file from stdin
+    local check_line
+    read -r check_line
+    
+    # For testing, always return success (checksums match)
+    # This allows tests to pass the new checksum validation
+    local file=$(echo "$check_line" | awk '{print $2}')
+    echo "$file: OK"
+    return 0
+  else
+    # Calculate checksum (for echo -n "$file_content" | sha256sum cases)
+    # Return a valid-looking checksum
+    echo "abc123def456789012345678901234567890123456789012345678901234567890  -"
   fi
 } 

--- a/tasks/validate-fbc-images-resolvable/validate-fbc-images-resolvable.yaml
+++ b/tasks/validate-fbc-images-resolvable/validate-fbc-images-resolvable.yaml
@@ -51,22 +51,46 @@ spec:
         # Install skopeo and jq from dnf
         dnf install -y skopeo jq
 
-        # Install yq manually as it's not in the default UBI repos
-        YQ_VERSION="v4.45.4"
+        # Determine architecture and ensure it is normalized to a consistent format used by the GitHub releases.
         ARCH=$(uname -m)
         if [[ "$ARCH" == "x86_64" ]]; then
           ARCH="amd64"
+        elif [[ "$ARCH" == "aarch64" ]]; then
+          ARCH="arm64"
         fi
+
+        # Define versions to be installed below
+        # SHA256 checksums depend on architecture, so they are defined later.
+        YQ_VERSION="v4.50.1"
+        YQ_SHA256=""
+        OPM_VERSION="v1.52.0"
+        OPM_SHA256=""
+
+        # Define SHA256 checksums for the specific architecture.
+        if [[ "$ARCH" == "amd64" ]]; then
+          YQ_SHA256="c7a1278e6bbc4924f41b56db838086c39d13ee25dcb22089e7fbf16ac901f0d4"
+          OPM_SHA256="ac863d6b1f93a7f0c400ab838b9c2d76b7e1c2ec9474f238a15da8873711b02d"
+        elif [[ "$ARCH" == "arm64" ]]; then
+          YQ_SHA256="cf0a663d8e4e00bb61507c5237b95b45a6aaa1fbedac77f4dc8abdadd5e2b745"
+          OPM_SHA256="ca20df87cd2f342b94bceb5eacba3fe57787377370e54669d64964659572c443"
+        fi
+
+        # Install yq
         curl -L \
           "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH}" \
           -o /usr/local/bin/yq
+        if [[ -n "$YQ_SHA256" ]]; then
+          echo "$YQ_SHA256 /usr/local/bin/yq" | sha256sum --check
+        fi
         chmod +x /usr/local/bin/yq
 
         # Install opm
-        OPM_VERSION="v1.52.0"
         curl -L \
           "https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-${ARCH}-opm" \
           -o /usr/local/bin/opm
+        if [[ -n "$OPM_SHA256" ]]; then
+          echo "$OPM_SHA256 /usr/local/bin/opm" | sha256sum --check
+        fi
         chmod +x /usr/local/bin/opm
 
         echo "--- Versions ---"


### PR DESCRIPTION
- It was recently observed that when Github is not in a healthy state, we do not necessarily receive the data we were expecting from the Github API
- When this occurs, it causes other steps to fail with very unusual looking errors as the task tries to execute an HTML error page as binary
- Instead, we should be validating that the data received from the API matches what was expecting by providing and verifying the sha256 checksum
- The checksums for the binaries used in the fbc validation pipeline are included in the script
- The checksum for the arbitrary file retreived using the download-file-from-git-repo task is now available as an optional parameter on the task