### PR TITLE
fix(CNF-22451): update jira task to use cloud api v3 auth and transit…

### DIFF
--- a/pipelines/update-jira-issues-pipeline/README.md
+++ b/pipelines/update-jira-issues-pipeline/README.md
@@ -17,9 +17,9 @@ The pipeline uses the `update-jira-issues` task to perform the actual JIRA updat
 | snapshot                | The namespaced name (namespace/name) of the snapshot                                          | No       | -                                                     |
 | taskGitUrl              | The url to the git repo where the community-catalog tasks to be used are stored              | Yes      | https://github.com/konflux-ci/community-catalog.git  |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                | Yes      | development                                          |
-| jira_server             | The server of the Jira instance to update issues on                                           | Yes      | issues.redhat.com                                     |
+| jira_server             | The server of the Jira instance to update issues on                                           | Yes      | redhat.atlassian.net                                     |
 | jira_project_regex      | The regex to match the Jira project to update issues on                                       | Yes      | "OCPBUGS-[0-9]+"                                      |
-| jira_target_state       | The target Jira state to transition issues to                                               | Yes      | "ON_QA"                                               |
+| jira_target_state       | The Jira transition target. Can match transition action name or destination status name     | Yes      | "ON_QA"                                               |
 | jira_skip_states        | The Jira states that should be skipped                                                      | Yes      | "Verified,Release Pending,Closed"                     |
 
 ## Workspaces
@@ -30,7 +30,9 @@ The pipeline uses the `update-jira-issues` task to perform the actual JIRA updat
 
 ## Prerequisites
 
-- A secret named `konflux-jira-secret` containing a `token` key with a valid Jira access token
+- A secret named `konflux-jira-secret` containing:
+  - a `user` key with a valid Jira Cloud username/email
+  - a `token` key with a valid Jira API token
 - A secret named `konflux-github-secret` containing a `token` key with a valid Github access token
 - The snapshot must contain at least one component with a container image
 - The container image must have `vcs-ref` and `url` labels pointing to a valid Git repository
@@ -47,13 +49,15 @@ The pipeline uses the `update-jira-issues` task to perform the actual JIRA updat
    - Checks the current status of the Jira issue
    - If the issue is in a skip state (e.g., "Verified", "Release Pending", "Closed"), skips processing
    - If the issue is not already in the target state:
+     - Resolves a transition by matching either transition action name (`.name`) or destination status name (`.to.name`) in a case-insensitive way
      - Transitions the issue to the target state
      - Adds a comment with the staging build information
 5. Continues processing remaining components
 
 ## Notes
 
-- Currently only supports issues in issues.redhat.com due to authentication requirements
+- Currently only supports issues in redhat.atlassian.net due to authentication requirements
 - Issues in other servers will be skipped without the pipeline failing
 - The pipeline uses the default regex pattern `OCPBUGS-[0-9]+` to match Red Hat OpenShift bug tracker issues
 - Issues in skip states (default: "Verified", "Release Pending", "Closed") will be skipped without processing
+- The default target value `ON_QA` is typically used as a destination status name (for example, `MODIFIED -> ON_QA`), but the input can also match a transition action label if that is what your workflow exposes

--- a/pipelines/update-jira-issues-pipeline/update-jira-issues-pipeline.yaml
+++ b/pipelines/update-jira-issues-pipeline/update-jira-issues-pipeline.yaml
@@ -34,7 +34,7 @@ spec:
     - name: jira_server
       type: string
       description: The server of the Jira instance to update issues on
-      default: issues.redhat.com
+      default: redhat.atlassian.net
     - name: jira_project_regex
       type: string
       description: The regex to match the Jira project to update issues on

--- a/tasks/update-jira-issues/README.md
+++ b/tasks/update-jira-issues/README.md
@@ -6,16 +6,16 @@ Updates Jira issues to a specified target state (default: ON_QA) when a staging 
 
 This task extracts Jira issue references from pull request titles in a release snapshot and updates those issues to a specified target state (default: "ON_QA"). It is designed to run after a staging build is released to automatically track issue progression.
 
-**Note:** This task currently only supports issues in issues.redhat.com due to authentication requirements. Issues in other servers will be skipped without the task failing.
+**Note:** This task currently only supports issues in redhat.atlassian.net due to authentication requirements. Issues in other servers will be skipped without the task failing.
 
 ## Parameters
 
 | Name               | Description                                                                                    | Optional | Default value                                         |
 |-------------------|------------------------------------------------------------------------------------------------|----------|-------------------------------------------------------|
 | snapshot          | The namespaced name (namespace/name) of the snapshot                                          | No       | -                                                     |
-| jira_server       | The server of the Jira instance to update issues on                                           | Yes      | issues.redhat.com                                     |
+| jira_server       | The server of the Jira instance to update issues on                                           | Yes      | redhat.atlassian.net                                     |
 | jira_project_regex| The regex to match the Jira project to update issues on                                       | Yes      | "OCPBUGS-[0-9]+"                                      |
-| jira_target_state| The target Jira state to transition issues to                                               | Yes      | "ON_QA"                                               |
+| jira_target_state| The Jira transition target. Can match transition action name or destination status name     | Yes      | "ON_QA"                                               |
 | jira_skip_states| The Jira states that should be skipped                                                      | Yes      | "Verified,Release Pending,Closed"                     |
 
 ## Workspaces
@@ -26,7 +26,9 @@ This task extracts Jira issue references from pull request titles in a release s
 
 ## Prerequisites
 
-- A secret named `konflux-jira-secret` containing a `token` key with a valid Jira access token
+- A secret named `konflux-jira-secret` containing:
+  - a `user` key with a valid Jira Cloud username/email
+  - a `token` key with a valid Jira API token
 - The snapshot must contain at least one component with a container image
 - The container image must have `vcs-ref` and `url` labels pointing to a valid Git repository
 - GitHub CLI (`gh`) must be available and configured for API access
@@ -41,6 +43,7 @@ This task extracts Jira issue references from pull request titles in a release s
    - Checks the current status of the Jira issue
    - If the issue is in a skip state (e.g., "Verified", "Release Pending", "Closed"), skips processing
    - If the issue is not already in the target state:
+     - Resolves a transition by matching either transition action name (`.name`) or destination status name (`.to.name`) in a case-insensitive way
      - Transitions the issue to the target state
      - Adds a comment with the staging build information
    - If the issue is already in the target state, skips processing
@@ -53,3 +56,4 @@ This task extracts Jira issue references from pull request titles in a release s
 - **Skip**: If an issue is in a skip state or already in the target state, that component is skipped and processing continues
 - **Error**: If no container images can be extracted from the snapshot, the task exits with code 1
 - **Error**: If a component has an empty image, the task exits with code 1
+- **Note**: The default target value `ON_QA` is typically used as a destination status name (for example, `MODIFIED -> ON_QA`), but task input may also match a transition action label if that is what your workflow exposes

--- a/tasks/update-jira-issues/tests/mocks.sh
+++ b/tasks/update-jira-issues/tests/mocks.sh
@@ -65,18 +65,18 @@ function jq() {
     echo "abc123def456"
   elif [[ "$*" == *".Labels[\"url\"]"* ]]; then
     echo "https://github.com/example/konflux-test-container.git"
-  elif [[ "$*" == *".transitions[] | select(.name==\"ON_QA\") | .id"* ]]; then
+  elif [[ "$*" == *".transitions[] |"* ]] && [[ "$*" == *"ascii_downcase"* ]]; then
     echo "123"
   elif [[ "$*" == *".fields.status.name"* ]]; then
     echo "ON_QA"
   elif [[ "$*" == *".servers[] | contains"* ]]; then
-    echo "rest/api/2/issue"
+    echo "rest/api/3/issue"
   elif [[ "$*" == *".[0] | \"\\(.title)\""* ]]; then
     echo "OCPBUGS-12345: Fix important OCP issue"
   elif [[ "$*" == *"[] | select(.servers[] | contains"* ]]; then
-    echo "rest/api/2/issue"
+    echo "rest/api/3/issue"
   elif [[ "$*" == *"select(.servers[] | contains"* ]]; then
-    echo "rest/api/2/issue"
+    echo "rest/api/3/issue"
   else
     echo Error: Unexpected jq call: $*
     exit 1
@@ -124,7 +124,7 @@ function curl-with-retry() {
 }
 EOF
     cat /tmp/mock_transitions.json
-  elif [[ "$*" == *"rest/api/2/issue"* ]] && [[ "$*" != *"transitions"* ]] && [[ "$*" != *"comment"* ]]; then
+  elif [[ "$*" == *"rest/api/3/issue"* ]] && [[ "$*" != *"transitions"* ]] && [[ "$*" != *"comment"* ]]; then
     # Mock issue status API response
     cat > /tmp/mock_issue_status.json <<EOF
 {

--- a/tasks/update-jira-issues/tests/pre-apply-task-hook.sh
+++ b/tasks/update-jira-issues/tests/pre-apply-task-hook.sh
@@ -9,7 +9,7 @@ yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[
 
 # Create a dummy jira secret (and delete it first if it exists)
 kubectl delete secret konflux-jira-secret --ignore-not-found
-kubectl create secret generic konflux-jira-secret --from-literal=token=dummy-token
+kubectl create secret generic konflux-jira-secret --from-literal=user=dummy-user@example.com --from-literal=token=dummy-token
 
 # Create a dummy github secret (and delete it first if it exists)
 kubectl delete secret konflux-github-secret --ignore-not-found

--- a/tasks/update-jira-issues/tests/test-update-jira-issues-skip-on-qa.yaml
+++ b/tasks/update-jira-issues/tests/test-update-jira-issues-skip-on-qa.yaml
@@ -18,7 +18,7 @@ spec:
         - name: snapshot
           value: "default/konflux-test-container-98765"
         - name: jira_server
-          value: "issues.redhat.com"
+          value: "redhat.atlassian.net"
         - name: jira_project_regex
           value: "OCPBUGS-[0-9]+"
         - name: jira_target_state

--- a/tasks/update-jira-issues/update-jira-issues.yaml
+++ b/tasks/update-jira-issues/update-jira-issues.yaml
@@ -12,7 +12,7 @@ spec:
     It is meant to run after a staging build is released.
     A comment will be added to the issue with a link to the staging build it was fixed in.
 
-    Note: This task currently only supports issues in issues.redhat.com due to it requiring authentication.
+    Note: This task currently only supports issues in redhat.atlassian.net due to it requiring authentication.
     Issues in other servers will be skipped without the task failing.
   params:
     - name: snapshot
@@ -21,7 +21,7 @@ spec:
     - name: jira_server
       type: string
       description: The server of the Jira instance to update issues on
-      default: issues.redhat.com
+      default: redhat.atlassian.net
     - name: jira_project_regex
       type: string
       description: The regex to match the Jira project to update issues on
@@ -38,6 +38,11 @@ spec:
     - name: update-issues
       image: quay.io/konflux-ci/release-service-utils:b7f90a1dde20efe9a4063c1082c4f0ce31113bb1
       env:
+        - name: JIRA_USER
+          valueFrom:
+            secretKeyRef:
+              name: konflux-jira-secret
+              key: user
         - name: JIRA_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:
@@ -55,10 +60,11 @@ spec:
 
         ISSUE_TRACKERS='{
             "Jira": {
-                "api": "rest/api/2/issue",
+                "api": "rest/api/3/issue",
                 "servers": [
                     "issues.redhat.com",
-                    "jira.atlassian.com"
+                    "jira.atlassian.com",
+                    "redhat.atlassian.net"
                 ]
             },
             "bugzilla": {
@@ -114,8 +120,19 @@ spec:
           echo "issue: $issue"
           echo "server: $server"
 
+          # Atlassian Cloud auth requires Basic base64(user:token).
+          if [ -z "${JIRA_USER:-}" ]; then
+              echo "Error: JIRA_USER is required for Jira Cloud Basic auth."
+              exit 1
+          fi
+          if [ -z "${JIRA_ACCESS_TOKEN:-}" ]; then
+              echo "Error: JIRA_ACCESS_TOKEN is required for Jira Cloud Basic auth."
+              exit 1
+          fi
+          jira_basic_auth="$(printf '%s:%s' "$JIRA_USER" "$JIRA_ACCESS_TOKEN" | base64 | tr -d '\n')"
+          jira_auth_header="Authorization: Basic $jira_basic_auth"
           CURL_ARGS=(
-              -H "Authorization: Bearer $JIRA_ACCESS_TOKEN"
+              -H "$jira_auth_header"
               --retry 3
           )
 
@@ -147,7 +164,11 @@ spec:
           STATUS_RC=0
           # Get the target state transition id. This varies per Jira project
           if ! STATUS_ID="$(curl-with-retry "${CURL_ARGS[@]}" "${API_URL}/transitions" \
-              | jq -er '.transitions[] | select(.name=="'"$target_state"'") | .id')"; then
+              | jq -er '.transitions[] |
+                  select(
+                    (.name | ascii_downcase) == ("'"$target_state"'" | ascii_downcase) or
+                    (.to.name | ascii_downcase) == ("'"$target_state"'" | ascii_downcase)
+                  ) | .id')"; then
               echo "Warning: failed to fetch the $target_state state id for issue $issue." \
                   "We most likely do not have permission to update it."
               STATUS_RC=1


### PR DESCRIPTION
…ions

Signed-off-by: Andres Gilgado <agilgado@redhat.com>

## Describe your changes


Switch the Jira task to Atlassian Cloud style authentication and API v3 endpoints, and update transition lookup to match both transition name and destination state name.

## Checklist before requesting a review
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
