### PR TITLE
fix: omit short SHA from incrementer filtering

### DIFF
--- a/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
+++ b/tasks/push-snapshot-to-quay/push-snapshot-to-quay.yaml
@@ -183,8 +183,9 @@ spec:
               # Incrementer templating
               if [[ "$tag" == *"{{ incrementer }}"* ]]; then
                 vp="${tag//\{\{ incrementer \}\}/}"
-                mn=$(skopeo list-tags --retry-times 3 docker://"$REPOSITORY" 2>/dev/null | \
-                  jq -r '.Tags[]' | grep -E "^${vp}[0-9]+$" | sed -E "s/${vp}//" | sort -nr | head -n1)
+                mn=$(skopeo list-tags --retry-times 3 docker://"$REPOSITORY" 2>/dev/null |
+                  jq -r '.Tags[]' | grep -v "^${vp}${git_sha:0:7}" | grep -E "^${vp}[0-9]+$" |
+                  sed -E "s/${vp}//" | sort -nr | head -n1)
                 tag="${tag//\{\{ incrementer \}\}/$((mn + 1))}"
               fi
               push_image "$NAME" "$CONTAINER_IMAGE" "$REPOSITORY" "$tag"


### PR DESCRIPTION
## Describe your changes

Fixes when a short SHA contains only digits, it's mistakenly returned and used as the incrementer value.

For example, this SHA:
```
07739678968cd3fbc2e5919c4c3b5056a1a2f0d1
```
Has a short SHA of:
```
0773967
```
Which is currently filtered and subsequently incremented on when listing tags. Or, in an even worse edge case, Bash thinks it's a base 8 number since it starts with zero and throws this error since it contains a 9:
```
/tekton/scripts/script-1-45zp2: line 124: 0773967: value too great for base (error token is "0773967")
```

## Checklist before requesting a review
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
