### PR TITLE
feat(RELEASE-2275): remove base directory

### DIFF
--- a/tasks/update-internal-services/tests/mocks.sh
+++ b/tasks/update-internal-services/tests/mocks.sh
@@ -23,8 +23,10 @@ function git() {
       "$gitRepo"/components/internal-services/internal-production/manager/manager-one.yaml \
       "$gitRepo"/components/internal-services/internal-production/manager/manager-two.yaml \
       "$gitRepo"/components/internal-services/internal-production/manager/manager-three.yaml
-    mkdir -p "$gitRepo"/components/internal-services/base/crd
-    mkdir -p "$gitRepo"/components/internal-services/base/rbac
+    mkdir -p "$gitRepo"/components/internal-services/internal-staging/crds
+    mkdir -p "$gitRepo"/components/internal-services/internal-staging/rbac
+    mkdir -p "$gitRepo"/components/internal-services/internal-production/crds
+    mkdir -p "$gitRepo"/components/internal-services/internal-production/rbac
   elif [[ "$*" == 'git log --format="%H"'* ]]; then
       echo abcdefg
       echo zyxwvu

--- a/tasks/update-internal-services/update-internal-services.yaml
+++ b/tasks/update-internal-services/update-internal-services.yaml
@@ -76,21 +76,21 @@ spec:
           BRANCH="internal-services-$(params.deployment)-manager-update"
           git checkout -b "$BRANCH"
 
-          # CRDs and RBAC are in base, so only copy them if it is a staging PR
-          if [[ "$(params.deployment)" == "staging" ]]; then
-              cp "${IS_REPO}/config/crd/bases/"*.yaml "components/internal-services/base/crds"
-              cp "${IS_REPO}/config/rbac/"*.yaml "components/internal-services/base/rbac"
-              # Remove namespace line in rbac files
-              find "components/internal-services/base/rbac" -type f \
-                -exec sed -i '/namespace: system/d' {} \;
-              # Add konflux-release-team group to role_binding.yaml
-              yq -i ".subjects += {\"kind\": \"Group\", \"name\": \"konflux-release-team\" }" \
-                components/internal-services/base/rbac/role_binding.yaml
-              # Maintain additional RBAC files that are not in upstream kustomization.yaml
-              echo "  - view-authenticated-users.yaml" >> components/internal-services/base/rbac/kustomization.yaml
-              echo "  - release_team_role.yaml" >> components/internal-services/base/rbac/kustomization.yaml
-              echo "  - release_team_role_binding.yaml" >> components/internal-services/base/rbac/kustomization.yaml
-          fi
+          OVERLAY_PATH="components/internal-services/internal-$(params.deployment)"
+          cp "${IS_REPO}/config/crd/bases/"*.yaml "${OVERLAY_PATH}/crds"
+          cp "${IS_REPO}/config/rbac/"*.yaml "${OVERLAY_PATH}/rbac"
+          # Remove namespace line in rbac files
+          find "${OVERLAY_PATH}/rbac" -type f \
+            -exec sed -i '/namespace: system/d' {} \;
+          # Add konflux-release-team group to role_binding.yaml
+          yq -i ".subjects += {\"kind\": \"Group\", \"name\": \"konflux-release-team\" }" \
+            "${OVERLAY_PATH}/rbac/role_binding.yaml"
+          # Maintain additional RBAC files that are not in upstream kustomization.yaml
+          {
+            echo "  - view-authenticated-users.yaml"
+            echo "  - release_team_role.yaml"
+            echo "  - release_team_role_binding.yaml"
+          } >> "${OVERLAY_PATH}/rbac/kustomization.yaml"
 
           PREV_COMMIT=$(grep -r "quay.io/konflux-ci/internal-services:" \
             "components/internal-services/internal-$(params.deployment)/manager" | head -n 1 | cut -d ':' -f 4)


### PR DESCRIPTION
## Describe your changes
The base directory is being removed from infra-common-deployments as part of [RELEASE-2275](https://redhat.atlassian.net/browse/RELEASE-2275).
For this to work, the task syncing the content from internal-services needs to be adjusted to not recreate the base dir.

Generated-by: Cursor

## Checklist before requesting a review
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)


[RELEASE-2275]: https://redhat.atlassian.net/browse/RELEASE-2275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ