### PR TITLE
chore: reenable scheduled promotion

### DIFF
--- a/.github/workflows/promote_branch.yaml
+++ b/.github/workflows/promote_branch.yaml
@@ -30,10 +30,9 @@ on:
         type: boolean
         required: true
         default: false
-  # All production promotions must be manually reviewed and approved.
-  # schedule:
-  #   # UTC time
-  #   - cron: "15 14 * * 3"
+  schedule:
+    # UTC time
+    - cron: "15 14 * * 1"
 permissions:
   contents: write
   actions: write


### PR DESCRIPTION
This commit turns the weekly promotion back on and moves it from Wednesday to Monday.

## Describe your changes

## Checklist before requesting a review
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
