### PR TITLE
fix: add extra rbac file in update-internal-services

### DIFF
--- a/tasks/update-internal-services/update-internal-services.yaml
+++ b/tasks/update-internal-services/update-internal-services.yaml
@@ -90,6 +90,7 @@ spec:
             echo "  - view-authenticated-users.yaml"
             echo "  - release_team_role.yaml"
             echo "  - release_team_role_binding.yaml"
+            echo "  - signing-sa.yaml"
           } >> "${OVERLAY_PATH}/rbac/kustomization.yaml"
 
           PREV_COMMIT=$(grep -r "quay.io/konflux-ci/internal-services:" \


### PR DESCRIPTION
## Describe your changes

The signing-sa is needed for rpm signing. Without this, the task will keep removing it from infra-common-deployments.

See here for context: https://redhat-internal.slack.com/archives/C031USXS2FJ/p1778527009000259

Also: https://github.com/redhat-appstudio/infra-common-deployments/pull/347

And an automated PR that is removing it: https://github.com/redhat-appstudio/infra-common-deployments/pull/348/changes

## Checklist before requesting a review
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
