### PR TITLE
RELEASE-2451: Remove hardcoded RBAC append in update-internal-services task

### DIFF
--- a/tasks/update-internal-services/update-internal-services.yaml
+++ b/tasks/update-internal-services/update-internal-services.yaml
@@ -85,13 +85,6 @@ spec:
           # Add konflux-release-team group to role_binding.yaml
           yq -i ".subjects += {\"kind\": \"Group\", \"name\": \"konflux-release-team\" }" \
             "${OVERLAY_PATH}/rbac/role_binding.yaml"
-          # Maintain additional RBAC files that are not in upstream kustomization.yaml
-          {
-            echo "  - view-authenticated-users.yaml"
-            echo "  - release_team_role.yaml"
-            echo "  - release_team_role_binding.yaml"
-            echo "  - signing-sa.yaml"
-          } >> "${OVERLAY_PATH}/rbac/kustomization.yaml"
 
           PREV_COMMIT=$(grep -r "quay.io/konflux-ci/internal-services:" \
             "components/internal-services/internal-$(params.deployment)/manager" | head -n 1 | cut -d ':' -f 4)


### PR DESCRIPTION
## Describe your changes

Remove logic that appends local-only RBAC files to rbac/kustomization.yaml. These files have been moved to a separate extra/ directory that is referenced in the parent kustomization.yaml (which is never touched by automation).

This makes the layout more sustainable and eliminates the need to maintain a hardcoded list in the task.

Note that this should be merged after https://github.com/redhat-appstudio/infra-common-deployments/pull/374 (technically it could be even before, but what matters is that we wouldn't want to merge a PR generated by this updated task before the files are in the new location in the infra-common-deployments repo)

## Checklist before requesting a review
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
