### PR TITLE
feat: add aws-oidc-auth task for credential-free AWS authentication

### DIFF
--- a/stepactions/aws-oidc-auth/README.md
+++ b/stepactions/aws-oidc-auth/README.md
@@ -1,0 +1,61 @@
+# aws-oidc-auth (StepAction)
+
+Authenticates to AWS using OIDC workload identity federation. Designed to be embedded
+as a step in custom Tasks. For a standalone Task, see `tasks/aws-oidc-auth`.
+
+## Parameters
+
+| Name                | Description                                              | Optional | Default value   |
+|---------------------|----------------------------------------------------------|----------|-----------------|
+| roleArn             | ARN of the IAM role to assume                            | No       | -               |
+| region              | AWS region for STS endpoint                              | Yes      | us-east-1       |
+| sessionDuration     | Duration in seconds for temporary credentials (900-43200)| Yes      | 900             |
+| oidcTokenVolume     | Name of the projected serviceAccountToken volume         | Yes      | oidc-token      |
+| awsCredentialsVolume| Name of the emptyDir volume for credentials              | Yes      | aws-credentials |
+
+## Usage
+
+The parent Task must declare two volumes. Subsequent steps mount the credentials volume
+and set `AWS_SHARED_CREDENTIALS_FILE`.
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: my-task-needing-aws
+spec:
+  volumes:
+    - name: oidc-token
+      projected:
+        sources:
+          - serviceAccountToken:
+              audience: sts.amazonaws.com
+              expirationSeconds: 3600
+              path: token
+    - name: aws-credentials
+      emptyDir:
+        medium: Memory
+        sizeLimit: 1Mi
+  steps:
+    - ref:
+        name: aws-oidc-auth
+      params:
+        - name: roleArn
+          value: arn:aws:iam::123456789012:role/my-role
+    - name: use-aws
+      image: amazon/aws-cli:latest
+      volumeMounts:
+        - name: aws-credentials
+          mountPath: /var/run/secrets/aws
+          readOnly: true
+      env:
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /var/run/secrets/aws/credentials
+      script: |
+        aws s3 ls s3://my-bucket/
+```
+
+## Security
+
+See `tasks/aws-oidc-auth/README.md` for full security details, prerequisites, and
+IAM trust policy configuration.

--- a/stepactions/aws-oidc-auth/aws-oidc-auth.yaml
+++ b/stepactions/aws-oidc-auth/aws-oidc-auth.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: aws-oidc-auth
+spec:
+  description: |-
+    Authenticates to AWS using OIDC workload identity federation.
+    Calls AWS STS AssumeRoleWithWebIdentity directly using a projected
+    ServiceAccount token. No broker or static credentials required.
+
+    Writes temporary AWS credentials to an in-memory volume for use
+    by subsequent steps in the same Task.
+
+    The parent Task must declare two volumes:
+      - A projected serviceAccountToken volume (audience: sts.amazonaws.com)
+      - An emptyDir (medium: Memory) volume for credentials
+  image: registry.access.redhat.com/ubi9-minimal:latest
+  params:
+    - name: roleArn
+      type: string
+      description: ARN of the IAM role to assume.
+    - name: region
+      type: string
+      default: us-east-1
+      description: AWS region for STS endpoint.
+    - name: sessionDuration
+      type: string
+      default: "900"
+      description: Duration in seconds for temporary credentials (900-43200).
+    - name: oidcTokenVolume
+      type: string
+      default: oidc-token
+      description: Name of the projected serviceAccountToken volume.
+    - name: awsCredentialsVolume
+      type: string
+      default: aws-credentials
+      description: Name of the emptyDir volume for writing credentials.
+  env:
+    - name: ROLE_ARN
+      value: "$(params.roleArn)"
+    - name: REGION
+      value: "$(params.region)"
+    - name: SESSION_DURATION
+      value: "$(params.sessionDuration)"
+  volumeMounts:
+    - name: $(params.oidcTokenVolume)
+      mountPath: /var/run/secrets/oidc
+      readOnly: true
+    - name: $(params.awsCredentialsVolume)
+      mountPath: /var/run/secrets/aws
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    set +x
+
+    TOKEN_FILE="/var/run/secrets/oidc/token"
+    CREDS_FILE="/var/run/secrets/aws/credentials"
+
+    if [ ! -f "${TOKEN_FILE}" ]; then
+      echo "ERROR: OIDC token not found at ${TOKEN_FILE}" >&2
+      echo "Ensure the parent Task declares a projected serviceAccountToken volume." >&2
+      exit 1
+    fi
+
+    RESPONSE=$(curl -s -X POST \
+      "https://sts.${REGION}.amazonaws.com/" \
+      --data-urlencode "Action=AssumeRoleWithWebIdentity" \
+      --data-urlencode "Version=2011-06-15" \
+      --data-urlencode "RoleArn=${ROLE_ARN}" \
+      --data-urlencode "RoleSessionName=konflux-${HOSTNAME}" \
+      --data-urlencode "WebIdentityToken=$(cat "${TOKEN_FILE}")" \
+      --data-urlencode "DurationSeconds=${SESSION_DURATION}")
+
+    ACCESS_KEY=$(echo "${RESPONSE}" | grep -oPm1 '(?<=<AccessKeyId>)[^<]+')
+    SECRET_KEY=$(echo "${RESPONSE}" | grep -oPm1 '(?<=<SecretAccessKey>)[^<]+')
+    SESSION_TOKEN=$(echo "${RESPONSE}" | grep -oPm1 '(?<=<SessionToken>)[^<]+')
+
+    if [ -z "${ACCESS_KEY}" ] || [ -z "${SECRET_KEY}" ] || [ -z "${SESSION_TOKEN}" ]; then
+      echo "ERROR: STS AssumeRoleWithWebIdentity failed." >&2
+      ERROR_MSG=$(echo "${RESPONSE}" | grep -oPm1 '(?<=<Message>)[^<]+' || true)
+      if [ -n "${ERROR_MSG}" ]; then
+        echo "AWS Error: ${ERROR_MSG}" >&2
+      fi
+      exit 1
+    fi
+
+    cat > "${CREDS_FILE}" <<CRED
+    [default]
+    aws_access_key_id=${ACCESS_KEY}
+    aws_secret_access_key=${SECRET_KEY}
+    aws_session_token=${SESSION_TOKEN}
+    CRED
+
+    chmod 0600 "${CREDS_FILE}"
+    echo "AWS OIDC authentication successful."

--- a/tasks/aws-oidc-auth/README.md
+++ b/tasks/aws-oidc-auth/README.md
@@ -1,0 +1,98 @@
+# aws-oidc-auth
+
+Authenticates to AWS using OIDC workload identity federation (STS `AssumeRoleWithWebIdentity`).
+No static AWS credentials required.
+
+Uses the pipeline ServiceAccount's projected token to obtain temporary AWS session credentials.
+Credentials are stored in an in-memory volume and never exposed via Task results or logs.
+
+## Parameters
+
+| Name            | Description                                                            | Optional | Default value |
+|-----------------|------------------------------------------------------------------------|----------|---------------|
+| roleArn         | ARN of the IAM role to assume                                          | No       | -             |
+| region          | AWS region for STS endpoint                                            | Yes      | us-east-1     |
+| sessionDuration | Duration in seconds for temporary credentials (900-43200)              | Yes      | 900           |
+| image           | Container image for the run step                                       | Yes      | ubi9-minimal  |
+| script          | Script to execute with AWS credentials available                       | Yes      | echo message  |
+
+## Prerequisites
+
+1. **Cluster OIDC issuer must be publicly accessible.** Verify:
+   ```bash
+   ISSUER=$(curl -sk "$(oc whoami --show-server)/.well-known/openid-configuration" | jq -r '.issuer')
+   curl -s "${ISSUER}/.well-known/openid-configuration"
+   ```
+
+2. **Register an AWS IAM OIDC identity provider** for the cluster's issuer:
+   ```bash
+   ISSUER_HOST=$(echo "${ISSUER}" | sed 's|https://||')
+   THUMBPRINT=$(openssl s_client -connect "${ISSUER_HOST%%/*}:443" \
+     -servername "${ISSUER_HOST%%/*}" </dev/null 2>/dev/null | \
+     openssl x509 -fingerprint -sha1 -noout | \
+     sed 's/://g' | cut -d= -f2 | tr '[:upper:]' '[:lower:]')
+
+   aws iam create-open-id-connect-provider \
+     --url "${ISSUER}" \
+     --client-id-list sts.amazonaws.com \
+     --thumbprint-list "${THUMBPRINT}"
+   ```
+
+3. **Create an IAM role** with a trust policy allowing the pipeline ServiceAccount:
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [{
+       "Effect": "Allow",
+       "Principal": {
+         "Federated": "arn:aws:iam::ACCOUNT:oidc-provider/ISSUER_HOST_AND_PATH"
+       },
+       "Action": "sts:AssumeRoleWithWebIdentity",
+       "Condition": {
+         "StringEquals": {
+           "ISSUER_HOST_AND_PATH:aud": "sts.amazonaws.com"
+         },
+         "StringLike": {
+           "ISSUER_HOST_AND_PATH:sub": "system:serviceaccount:NAMESPACE:build-pipeline-*"
+         }
+       }
+     }]
+   }
+   ```
+
+## Usage
+
+```yaml
+- name: aws-task
+  taskRef:
+    name: aws-oidc-auth
+  params:
+    - name: roleArn
+      value: arn:aws:iam::123456789012:role/my-role
+    - name: image
+      value: amazon/aws-cli:latest
+    - name: script
+      value: |
+        aws sts get-caller-identity
+        aws s3 cp s3://my-bucket/config.yaml /tmp/config.yaml
+```
+
+## Security
+
+- The `authenticate` step runs with `set +x` for its entirety — shell tracing cannot leak the OIDC token, STS response, or credentials.
+- No Task `results` are defined — credentials cannot leak to PipelineRun status or Tekton Results.
+- Credentials are stored in an in-memory `emptyDir` volume (`medium: Memory`) with `0600` permissions — never written to disk.
+- The OIDC token volume is only mounted in the `authenticate` step — the `run` step cannot access the raw ServiceAccount token.
+- The credentials volume is mounted read-only in the `run` step.
+- The volume is destroyed when the pod terminates.
+- Use short `sessionDuration` values and least-privilege IAM policies.
+
+## Scoping access
+
+IAM trust policy `sub` conditions map to Kubernetes ServiceAccount names:
+
+| Scope | Condition |
+|-------|-----------|
+| All builds in namespace | `system:serviceaccount:NAMESPACE:build-pipeline-*` |
+| Single component | `system:serviceaccount:NAMESPACE:build-pipeline-COMPONENT` |
+| Integration tests | `system:serviceaccount:NAMESPACE:konflux-integration-runner` |

--- a/tasks/aws-oidc-auth/aws-oidc-auth.yaml
+++ b/tasks/aws-oidc-auth/aws-oidc-auth.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: aws-oidc-auth
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "aws, oidc, authentication"
+spec:
+  description: |-
+    Authenticates to AWS using OIDC workload identity federation.
+    Uses the pipeline ServiceAccount's projected token to call AWS STS
+    AssumeRoleWithWebIdentity directly. No broker or static credentials required.
+
+    Temporary credentials are written to an in-memory volume shared
+    between steps. They are never exposed via Task results or logs.
+
+    This Task wraps the aws-oidc-auth StepAction from this repository.
+  params:
+    - name: roleArn
+      description: ARN of the IAM role to assume.
+    - name: region
+      description: AWS region for STS endpoint.
+      default: us-east-1
+    - name: sessionDuration
+      description: Duration in seconds for temporary credentials (900-43200).
+      default: "900"
+    - name: image
+      description: Container image for the run step.
+      default: registry.access.redhat.com/ubi9-minimal:latest
+    - name: script
+      description: |-
+        Script to execute with AWS credentials available.
+        AWS_SHARED_CREDENTIALS_FILE and AWS_DEFAULT_REGION are pre-configured.
+      default: "echo 'AWS credentials available. Override this param with your script.'"
+  volumes:
+    - name: oidc-token
+      projected:
+        sources:
+          - serviceAccountToken:
+              audience: sts.amazonaws.com
+              expirationSeconds: 3600
+              path: token
+    - name: aws-credentials
+      emptyDir:
+        medium: Memory
+        sizeLimit: 1Mi
+  steps:
+    - name: authenticate
+      ref:
+        name: aws-oidc-auth
+      params:
+        - name: roleArn
+          value: $(params.roleArn)
+        - name: region
+          value: $(params.region)
+        - name: sessionDuration
+          value: $(params.sessionDuration)
+    - name: run
+      image: $(params.image)
+      volumeMounts:
+        - name: aws-credentials
+          mountPath: /var/run/secrets/aws
+          readOnly: true
+      env:
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /var/run/secrets/aws/credentials
+        - name: AWS_DEFAULT_REGION
+          value: $(params.region)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        # shellcheck disable=SC2091
+        $(params.script)

--- a/tasks/aws-oidc-auth/tests/mocks.sh
+++ b/tasks/aws-oidc-auth/tests/mocks.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -eux
+
+# mocks to be injected into task step scripts
+
+function curl() {
+  # Log call without printing sensitive arguments (WebIdentityToken)
+  echo "Mock curl called" >&2
+
+  if [[ "$*" == *"AssumeRoleWithWebIdentity"* ]]; then
+    # Validate required parameters are present
+    if [[ "$*" != *"RoleArn="* ]]; then
+      echo "Error: Missing RoleArn parameter" >&2
+      exit 1
+    fi
+    if [[ "$*" != *"WebIdentityToken="* ]]; then
+      echo "Error: Missing WebIdentityToken parameter" >&2
+      exit 1
+    fi
+
+    # Check for invalid role ARN test case
+    if [[ "$*" == *"invalid-role"* ]]; then
+      cat <<'XMLEOF'
+<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <Error>
+    <Type>Sender</Type>
+    <Code>AccessDenied</Code>
+    <Message>Not authorized to perform sts:AssumeRoleWithWebIdentity</Message>
+  </Error>
+</ErrorResponse>
+XMLEOF
+      return 0
+    fi
+
+    # Return mock STS response
+    cat <<'XMLEOF'
+<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <AccessKeyId>ASIAMOCKACCESSKEYID00</AccessKeyId>
+      <SecretAccessKey>MockSecretAccessKey1234567890abcdefghijk</SecretAccessKey>
+      <SessionToken>MockSessionToken1234567890abcdefghijklmnopqrstuvwxyz</SessionToken>
+      <Expiration>2099-01-01T00:00:00Z</Expiration>
+    </Credentials>
+    <SubjectFromWebIdentityToken>system:serviceaccount:test-ns:test-sa</SubjectFromWebIdentityToken>
+    <AssumedRoleUser>
+      <AssumedRoleId>AROAMOCKROLEID:konflux-test</AssumedRoleId>
+      <Arn>arn:aws:sts::123456789012:assumed-role/test-role/konflux-test</Arn>
+    </AssumedRoleUser>
+  </AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>
+XMLEOF
+    return 0
+  fi
+
+  # Default: pass through
+  command curl "$@"
+}
+export -f curl

--- a/tasks/aws-oidc-auth/tests/pre-apply-task-hook.sh
+++ b/tasks/aws-oidc-auth/tests/pre-apply-task-hook.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -x
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../.." && pwd)
+
+# Install the StepAction that the Task references
+STEPACTION_PATH="${REPO_ROOT}/stepactions/aws-oidc-auth/aws-oidc-auth.yaml"
+STEPACTION_COPY=$(mktemp)
+cp "$STEPACTION_PATH" "$STEPACTION_COPY"
+
+# Add mocks to the StepAction script
+yq -i '.spec.script = load_str("'"$SCRIPT_DIR"'/mocks.sh") + .spec.script' "$STEPACTION_COPY"
+kubectl apply -f "$STEPACTION_COPY"
+rm -f "$STEPACTION_COPY"
+
+# Replace the projected serviceAccountToken volume with an emptyDir
+# since kind clusters don't have a real OIDC provider
+yq -i '.spec.volumes[0] = {"name": "oidc-token", "emptyDir": {}}' "$TASK_PATH"
+
+# Prepend a step that creates a fake OIDC token
+yq -i '.spec.steps = [
+  {
+    "name": "setup-fake-token",
+    "image": "registry.access.redhat.com/ubi9-minimal:latest",
+    "volumeMounts": [{"name": "oidc-token", "mountPath": "/var/run/secrets/oidc"}],
+    "script": "#!/bin/bash\necho -n \"eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rlc3QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6dGVzdC1uczp0ZXN0LXNhIiwiYXVkIjpbInN0cy5hbWF6b25hd3MuY29tIl19.fake-signature\" > /var/run/secrets/oidc/token"
+  }
+] + .spec.steps' "$TASK_PATH"

--- a/tasks/aws-oidc-auth/tests/test-aws-oidc-auth-invalid-role.yaml
+++ b/tasks/aws-oidc-auth/tests/test-aws-oidc-auth-invalid-role.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-aws-oidc-auth-invalid-role
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the aws-oidc-auth task with an invalid role ARN and verify that
+    the task fails with an appropriate error message.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: aws-oidc-auth
+      params:
+        - name: roleArn
+          value: "arn:aws:iam::123456789012:role/invalid-role"
+        - name: region
+          value: "us-east-1"

--- a/tasks/aws-oidc-auth/tests/test-aws-oidc-auth-no-leak.yaml
+++ b/tasks/aws-oidc-auth/tests/test-aws-oidc-auth-no-leak.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-aws-oidc-auth-no-leak
+spec:
+  description: |
+    Run the aws-oidc-auth task and verify that the OIDC token is not
+    accessible from the run step.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: aws-oidc-auth
+      params:
+        - name: roleArn
+          value: "arn:aws:iam::123456789012:role/test-role"
+        - name: region
+          value: "us-east-1"
+        - name: script
+          value: |
+            # Verify the OIDC token volume is NOT mounted in the run step
+            if [ -f "/var/run/secrets/oidc/token" ]; then
+              echo "ERROR: OIDC token is accessible in run step" >&2
+              exit 1
+            fi
+
+            # Verify credentials file IS accessible
+            test -f "${AWS_SHARED_CREDENTIALS_FILE}"
+
+            # Verify the credentials volume is mounted read-only by
+            # attempting to write and confirming failure
+            if echo "test" > /var/run/secrets/aws/test-write 2>/dev/null; then
+              echo "ERROR: credentials volume is writable in run step" >&2
+              exit 1
+            fi
+
+            echo "No leak checks passed."

--- a/tasks/aws-oidc-auth/tests/test-aws-oidc-auth-success.yaml
+++ b/tasks/aws-oidc-auth/tests/test-aws-oidc-auth-success.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-aws-oidc-auth-success
+spec:
+  description: |
+    Run the aws-oidc-auth task and verify that credentials are written
+    to the in-memory volume with correct format and permissions.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: aws-oidc-auth
+      params:
+        - name: roleArn
+          value: "arn:aws:iam::123456789012:role/test-role"
+        - name: region
+          value: "us-east-1"
+        - name: script
+          value: |
+            # Verify credentials file exists and is readable
+            test -f "${AWS_SHARED_CREDENTIALS_FILE}"
+
+            # Verify credentials file contains expected keys
+            grep -q "aws_access_key_id" "${AWS_SHARED_CREDENTIALS_FILE}"
+            grep -q "aws_secret_access_key" "${AWS_SHARED_CREDENTIALS_FILE}"
+            grep -q "aws_session_token" "${AWS_SHARED_CREDENTIALS_FILE}"
+
+            # Verify credential values match mock response
+            grep -q "ASIAMOCKACCESSKEYID00" "${AWS_SHARED_CREDENTIALS_FILE}"
+            grep -q "MockSecretAccessKey1234567890abcdefghijk" "${AWS_SHARED_CREDENTIALS_FILE}"
+            grep -q "MockSessionToken1234567890abcdefghijklmnopqrstuvwxyz" "${AWS_SHARED_CREDENTIALS_FILE}"
+
+            # Verify file permissions are restrictive
+            PERMS=$(stat -c '%a' "${AWS_SHARED_CREDENTIALS_FILE}")
+            if [ "${PERMS}" != "600" ]; then
+              echo "ERROR: Credentials file permissions are ${PERMS}, expected 600" >&2
+              exit 1
+            fi
+
+            # Verify env vars are set
+            test -n "${AWS_SHARED_CREDENTIALS_FILE}"
+            test "${AWS_DEFAULT_REGION}" = "us-east-1"
+
+            echo "All checks passed."


### PR DESCRIPTION
## Summary

- Add `aws-oidc-auth` Tekton StepAction and Task enabling Konflux pipelines to authenticate to AWS using OIDC workload identity federation (STS `AssumeRoleWithWebIdentity`)
- Eliminates the need for static AWS IAM credentials (access key / secret key) in pipeline secrets
- Temporary credentials are stored in an in-memory volume and never exposed via Task results or logs

## How it works

1. A projected ServiceAccount token with `sts.amazonaws.com` audience is mounted into the task
2. The `authenticate` step (StepAction) exchanges the token for temporary AWS credentials via STS
3. Credentials are written to an in-memory `emptyDir` volume (`medium: Memory`) with `0600` permissions
4. The `run` step executes the user's script with `AWS_SHARED_CREDENTIALS_FILE` pre-configured

## What's included

- **StepAction** (`stepactions/aws-oidc-auth`) — composable step for embedding AWS auth into custom Tasks
- **Task** (`tasks/aws-oidc-auth`) — standalone wrapper with `image` and `script` params for simple use cases. References the StepAction.

## Security

- Shell tracing (`set +x`) is disabled for the entire `authenticate` step
- No Task `results` defined — credentials cannot leak to PipelineRun status or Tekton Results
- OIDC token volume is only mounted in the `authenticate` step, not the `run` step
- Credentials volume is mounted read-only in the `run` step
- In-memory volume destroyed when the pod terminates

## Prerequisites

Cluster OIDC issuer must be publicly accessible (standard for ROSA/OSD/managed OpenShift). Users must register an AWS IAM OIDC provider and create an IAM role with a trust policy scoped to their pipeline ServiceAccounts. Full setup instructions in README.

## Tested on

- Konflux production cluster (`kflux-prd-rh03`) — successful `AssumeRoleWithWebIdentity` + `GetCallerIdentity` with zero credential leakage in logs
- kind cluster with Tekton + real AWS account — Task and StepAction verified end-to-end

## Test plan

- [x] `test-aws-oidc-auth-success` — credentials written with correct format, mock values, `0600` permissions, env vars set
- [x] `test-aws-oidc-auth-invalid-role` — task fails on STS error (expected failure)
- [x] `test-aws-oidc-auth-no-leak` — OIDC token inaccessible from `run` step, credentials volume read-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)