### PR TITLE
fix(STONEINTG-1719): use finalizer as a param

### DIFF
--- a/pipelines/sanitize-and-push-plr/README.md
+++ b/pipelines/sanitize-and-push-plr/README.md
@@ -7,31 +7,32 @@ Intended to run after a managed release pipeline has pushed the container image 
 
 After a managed release pipeline completes, this pipeline:
 
-1. Finds the source build PipelineRun via the `appstudio.openshift.io/build-pipelinerun` label on the Snapshot. If the label is absent, falls back to a label selector filtered by the `test.appstudio.openshift.io/pipelinerun` finalizer.
+1. Finds the source build PipelineRun via the `appstudio.openshift.io/build-pipelinerun` label on the Snapshot. If the label is absent, falls back to a label selector filtered by the `finalizer` parameter (default `test.appstudio.openshift.io/sanitize-pipelinerun`).
 2. Sanitizes the PipelineRun JSON by stripping volatile metadata (uid, resourceVersion, timestamps, managedFields), integration-service labels and annotations, and execution status fields that differ on every run.
 3. Replaces the `IMAGE_URL` and `IMAGE_DIGEST` results in the sanitized PipelineRun with the permanently released image location so downstream consumers reference the correct registry.
 4. Pushes the sanitized PipelineRun as an OCI artifact (`application/vnd.appstudio.pipelinerun+json`) to the target Quay repository with two tags:
    - `<componentName>-latest` — overwritten on every run
    - `<componentName>-YYYYMMDD-HHMMSS` — timestamped snapshot for rollback
-5. On success, removes the `test.appstudio.openshift.io/pipelinerun` finalizer from the source PipelineRun so it can be garbage-collected by the cluster. On failure the finalizer is intentionally preserved for investigation.
+5. On success, removes the finalizer (default `test.appstudio.openshift.io/sanitize-pipelinerun`) from the source PipelineRun so it can be garbage-collected by the cluster. On failure the finalizer is intentionally preserved for investigation.
 
 ## Parameters
 
-| Name | Description | Optional | Default value |
-|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------|
-| release | The namespaced name (namespace/name) of the Release custom resource | No | - |
-| snapshot | The namespaced name (namespace/name) of the Snapshot | No | - |
-| releasePlan | The namespaced name (namespace/name) of the ReleasePlan | No | - |
-| componentName | The Konflux component name, used to find the source build PipelineRun and prefix OCI artifact tags | No | - |
-| ociArtifactRepo | Quay repository to push the sanitized PipelineRun OCI artifact to | No | - |
-| ociArtifactSecret | Name of the `kubernetes.io/dockerconfigjson` Secret in the tenant namespace with push credentials for the target Quay repository. Auth key must be `quay.io`. | No | - |
-| releasedImageRepo | Repository where the managed pipeline released the container image (e.g. `quay.io/my-org/my-image`). Used to set `IMAGE_URL` in the sanitized PipelineRun. Defaults to `ociArtifactRepo` if empty. | Yes | "" |
+| Name              | Description                                                                                                                                                                                        | Optional | Default value                                      |
+|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|----------------------------------------------------|
+| release           | The namespaced name (namespace/name) of the Release custom resource                                                                                                                                | No       | -                                                  |
+| snapshot          | The namespaced name (namespace/name) of the Snapshot                                                                                                                                               | No       | -                                                  |
+| releasePlan       | The namespaced name (namespace/name) of the ReleasePlan                                                                                                                                            | No       | -                                                  |
+| componentName     | The Konflux component name, used to find the source build PipelineRun and prefix OCI artifact tags                                                                                                 | No       | -                                                  |
+| ociArtifactRepo   | Quay repository to push the sanitized PipelineRun OCI artifact to                                                                                                                                  | No       | -                                                  |
+| ociArtifactSecret | Name of the `kubernetes.io/dockerconfigjson` Secret in the tenant namespace with push credentials for the target Quay repository. Auth key must be `quay.io`.                                      | No       | -                                                  |
+| releasedImageRepo | Repository where the managed pipeline released the container image (e.g. `quay.io/my-org/my-image`). Used to set `IMAGE_URL` in the sanitized PipelineRun. Defaults to `ociArtifactRepo` if empty. | Yes      | ""                                                 |
+| finalizer         | The finalizer that was set on the pipelineRun to prevent it being pruned before it is sanitized and pushed.                                                                                        | Yes      | "test.appstudio.openshift.io/sanitize-pipelinerun" |
 
 ## Prerequisites
 
-- The build push pipeline must add the finalizer
-  `test.appstudio.openshift.io/pipelinerun` to the build PipelineRun. This prevents
-  the PipelineRun from being garbage-collected before this pipeline can process it.
+- The build push pipeline must add the finalizer specified by the `finalizer` 
+  parameter (default `test.appstudio.openshift.io/sanitize-pipelinerun`) to the build PipelineRun. 
+  This prevents the PipelineRun from being garbage-collected before this pipeline can process it.
 - A `kubernetes.io/dockerconfigjson` Secret named by `ociArtifactSecret` must exist in
   the tenant namespace with push credentials to the target Quay repository. The secret
   must use `quay.io` as the auth key (not the full repository path).

--- a/pipelines/sanitize-and-push-plr/sanitize-and-push-plr.yaml
+++ b/pipelines/sanitize-and-push-plr/sanitize-and-push-plr.yaml
@@ -49,6 +49,12 @@ spec:
         value written into the sanitized PipelineRun. Defaults to ociArtifactRepo
         if left empty, which is correct when both point to the same repository.
       default: ""
+    - name: finalizer
+      type: string
+      description: >-
+        The finalizer that was set on the pipelineRun to prevent it being pruned before
+        it is sanitized and pushed.
+      default: "test.appstudio.openshift.io/sanitize-pipelinerun"
   tasks:
     - name: sanitize-and-push-plr
       params:
@@ -62,6 +68,8 @@ spec:
           value: $(params.ociArtifactSecret)
         - name: releasedImageRepo
           value: $(params.releasedImageRepo)
+        - name: finalizer
+          value: $(params.finalizer)
       taskSpec:
         params:
           - name: snapshot
@@ -73,6 +81,8 @@ spec:
           - name: ociArtifactSecret
             type: string
           - name: releasedImageRepo
+            type: string
+          - name: finalizer
             type: string
         volumes:
           - name: workdir
@@ -95,6 +105,8 @@ spec:
                 value: $(params.ociArtifactRepo)
               - name: RELEASED_IMAGE_REPO
                 value: $(params.releasedImageRepo)
+              - name: FINALIZER
+                value: $(params.finalizer)
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -133,9 +145,9 @@ spec:
                 PLR_NAME=$(kubectl get pipelinerun -n "${SNAPSHOT_NAMESPACE}" \
                   -l "appstudio.openshift.io/component=${COMPONENT_NAME}" \
                   -l "pipelines.appstudio.openshift.io/type=build" \
-                  -o json | jq -r '
+                  -o json | jq -r --arg finalizer "${FINALIZER}" '
                     [.items[] | select(
-                      .metadata.finalizers[]? == "test.appstudio.openshift.io/pipelinerun"
+                      .metadata.finalizers[]? == $finalizer
                     )]
                     | sort_by(.metadata.creationTimestamp)
                     | .[-1].metadata.name // empty')
@@ -143,7 +155,7 @@ spec:
 
               if [[ -z "${PLR_NAME}" || "${PLR_NAME}" == "null" ]]; then
                 echo "ERROR: Could not find a build PipelineRun for component ${COMPONENT_NAME}" >&2
-                echo "Ensure the build push pipeline adds finalizer test.appstudio.openshift.io/pipelinerun" >&2
+                echo "Ensure the build push pipeline adds finalizer ${FINALIZER}" >&2
                 exit 1
               fi
               echo "Source PipelineRun: ${PLR_NAME}"
@@ -260,11 +272,15 @@ spec:
           value: $(params.snapshot)
         - name: componentName
           value: $(params.componentName)
+        - name: finalizer
+          value: $(params.finalizer)
       taskSpec:
         params:
           - name: snapshot
             type: string
           - name: componentName
+            type: string
+          - name: finalizer
             type: string
         steps:
           - name: patch
@@ -274,6 +290,8 @@ spec:
                 value: $(params.snapshot)
               - name: COMPONENT_NAME
                 value: $(params.componentName)
+              - name: FINALIZER
+                value: $(params.finalizer)
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -292,9 +310,9 @@ spec:
                 PLR_NAME=$(kubectl get pipelinerun -n "${SNAPSHOT_NAMESPACE}" \
                   -l "appstudio.openshift.io/component=${COMPONENT_NAME}" \
                   -l "pipelines.appstudio.openshift.io/type=build" \
-                  -o json | jq -r '
+                  -o json | jq -r --arg finalizer "${FINALIZER}" '
                     [.items[] | select(
-                      .metadata.finalizers[]? == "test.appstudio.openshift.io/pipelinerun"
+                      .metadata.finalizers[]? == $finalizer
                     )]
                     | sort_by(.metadata.creationTimestamp)
                     | .[-1].metadata.name // empty')
@@ -306,14 +324,14 @@ spec:
               fi
 
               echo "Removing finalizer from PipelineRun ${PLR_NAME} in ${SNAPSHOT_NAMESPACE}..."
-              FINALIZERS=$(kubectl get pipelinerun "${PLR_NAME}" \
+              finalizers=$(kubectl get pipelinerun "${PLR_NAME}" \
                 -n "${SNAPSHOT_NAMESPACE}" \
-                -o json | jq -c \
-                  '[.metadata.finalizers[]? | select(. != "test.appstudio.openshift.io/pipelinerun")]')
+                -o json | jq -c --arg finalizer "${FINALIZER}" \
+                  '[.metadata.finalizers[]? | select(. != $finalizer)]')
 
               kubectl patch pipelinerun "${PLR_NAME}" \
                 -n "${SNAPSHOT_NAMESPACE}" \
                 --type=merge \
-                -p "{\"metadata\":{\"finalizers\":${FINALIZERS}}}" \
+                -p "{\"metadata\":{\"finalizers\":${finalizers}}}" \
                 && echo "Finalizer removed." \
                 || echo "PipelineRun gone or patch failed; skipping."


### PR DESCRIPTION
* Set the finalizer parameter and use that instead of the hardcoded finalizer
* Set the default value of the new parameter to `test.appstudio.openshift.io/sanitize-pipelinerun`

Breaking: callers must update their build pipeline to add finalizer test.appstudio.openshift.io/sanitize-pipelinerun or make sure that they set the `finalizer` parameter to match their existing finalizer. The old finalizer test.appstudio.openshift.io/pipelinerun is no longer matched by default.

Signed-off-by: dirgim <kpavic@redhat.com>

## Describe your changes

## Checklist before requesting a review
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
